### PR TITLE
Fix header for timings category

### DIFF
--- a/docs/paper/reference/paper-global-configuration.md
+++ b/docs/paper/reference/paper-global-configuration.md
@@ -259,7 +259,7 @@ function itself. For per-world configuration, see the
     - **default**: Flying is not enabled on this server
     - **description**: Message to use when kicking a player's vehicle for flying.
 
-## timings
+### timings
 
 - enabled
 


### PR DESCRIPTION
Because the header was set to `##` instead of `###`, some settings were unintentionally added as children of the timings category:
<img width="198" alt="image" src="https://user-images.githubusercontent.com/44026893/157384697-baaae502-7ceb-4a40-8c3a-d91a14b6181c.png">
