### PR TITLE
Breadcrumb links to all pages, category indexes

### DIFF
--- a/config/navbar.config.ts
+++ b/config/navbar.config.ts
@@ -1,8 +1,8 @@
-import {Navbar} from "@docusaurus/theme-common";
+import { Navbar } from "@docusaurus/theme-common";
 
-const navbar: Omit<Navbar, "style"> = { // don't specify style here, we want it to be dynamic
+// don't specify style or hideOnScroll here, we want it to be dynamic
+const navbar: Omit<Navbar, "style" | "hideOnScroll"> = {
   title: "PaperMC Docs",
-  hideOnScroll: true,
   logo: {
     src: "img/logo.svg",
     alt: "PaperMC Logo",

--- a/config/sidebars.config.ts
+++ b/config/sidebars.config.ts
@@ -3,9 +3,20 @@ import type { SidebarsConfig } from "@docusaurus/plugin-content-docs";
 const sidebars: SidebarsConfig = {
   docs: [
     {
-      type: "link",
-      label: "Support Discord",
-      href: "https://discord.gg/papermc",
+      type: "category",
+      label: "Getting Help",
+      items: [
+        {
+          type: "link",
+          label: "Discord",
+          href: "https://discord.gg/papermc",
+        },
+        {
+          type: "link",
+          label: "Forums",
+          href: "https://forums.papermc.io",
+        },
+      ],
     },
     "README",
     {
@@ -33,7 +44,8 @@ const sidebars: SidebarsConfig = {
           type: "category",
           label: "How-to Guides",
           link: {
-            type: "generated-index"
+            type: "generated-index",
+            slug: "/category/paper/how-to-guides",
           },
           items: [
             "paper/how-to/per-world-configuration",
@@ -47,6 +59,7 @@ const sidebars: SidebarsConfig = {
           label: "Reference",
           link: {
             type: "generated-index",
+            slug: "/category/paper/reference",
           },
           items: [
             "paper/reference/paper-global-configuration",
@@ -81,7 +94,8 @@ const sidebars: SidebarsConfig = {
           type: "category",
           label: "How-to Guides",
           link: {
-            type: "generated-index"
+            type: "generated-index",
+            slug: "/category/velocity/how-to-guides",
           },
           items: [
             "velocity/how-to/security",
@@ -94,6 +108,7 @@ const sidebars: SidebarsConfig = {
           label: "Reference",
           link: {
             type: "generated-index",
+            slug: "/category/velocity/reference",
           },
           items: [
             "velocity/reference/configuration",
@@ -116,7 +131,8 @@ const sidebars: SidebarsConfig = {
               type: "category",
               label: "Getting Started",
               link: {
-                type: "generated-index"
+                type: "generated-index",
+                slug: "/category/velocity/developers/getting-started",
               },
               items: [
                 "velocity/developers/getting-started/creating-your-first-plugin",
@@ -128,7 +144,8 @@ const sidebars: SidebarsConfig = {
               type: "category",
               label: "How-to Guides",
               link: {
-                type: "generated-index"
+                type: "generated-index",
+                slug: "/category/velocity/developers/how-to-guides",
               },
               items: [
                 "velocity/developers/how-to/dependencies",
@@ -139,7 +156,8 @@ const sidebars: SidebarsConfig = {
               type: "category",
               label: "API",
               link: {
-                type: "generated-index"
+                type: "generated-index",
+                slug: "/category/velocity/developers/api",
               },
               items: [
                 "velocity/developers/api/event",
@@ -164,7 +182,9 @@ const sidebars: SidebarsConfig = {
       type: "category",
       label: "Common",
       link: {
-        type: "generated-index"
+        type: "generated-index",
+        slug: "/category/common",
+        description: "Documentation relevant to all PaperMC projects.",
       },
       items: ["common/java-install"],
     },
@@ -172,7 +192,9 @@ const sidebars: SidebarsConfig = {
       type: "category",
       label: "PaperMC",
       link: {
-        type: "generated-index"
+        type: "generated-index",
+        slug: "/category/papermc",
+        description: "Information about the PaperMC Organization.",
       },
       items: ["papermc/downloads-api", "papermc/assets", "papermc/contact"],
     },

--- a/config/sidebars.config.ts
+++ b/config/sidebars.config.ts
@@ -32,6 +32,9 @@ const sidebars: SidebarsConfig = {
         {
           type: "category",
           label: "How-to Guides",
+          link: {
+            type: "generated-index"
+          },
           items: [
             "paper/how-to/per-world-configuration",
             "paper/how-to/anti-xray",
@@ -42,6 +45,9 @@ const sidebars: SidebarsConfig = {
         {
           type: "category",
           label: "Reference",
+          link: {
+            type: "generated-index",
+          },
           items: [
             "paper/reference/paper-global-configuration",
             "paper/reference/paper-per-world-configuration",
@@ -74,6 +80,9 @@ const sidebars: SidebarsConfig = {
         {
           type: "category",
           label: "How-to Guides",
+          link: {
+            type: "generated-index"
+          },
           items: [
             "velocity/how-to/security",
             "velocity/how-to/tuning",
@@ -83,6 +92,9 @@ const sidebars: SidebarsConfig = {
         {
           type: "category",
           label: "Reference",
+          link: {
+            type: "generated-index",
+          },
           items: [
             "velocity/reference/configuration",
             "velocity/reference/commands",
@@ -103,6 +115,9 @@ const sidebars: SidebarsConfig = {
             {
               type: "category",
               label: "Getting Started",
+              link: {
+                type: "generated-index"
+              },
               items: [
                 "velocity/developers/getting-started/creating-your-first-plugin",
                 "velocity/developers/getting-started/api-basics",
@@ -112,6 +127,9 @@ const sidebars: SidebarsConfig = {
             {
               type: "category",
               label: "How-to Guides",
+              link: {
+                type: "generated-index"
+              },
               items: [
                 "velocity/developers/how-to/dependencies",
                 "velocity/developers/how-to/porting-from-velocity-1",
@@ -120,6 +138,9 @@ const sidebars: SidebarsConfig = {
             {
               type: "category",
               label: "API",
+              link: {
+                type: "generated-index"
+              },
               items: [
                 "velocity/developers/api/event",
                 "velocity/developers/api/command",
@@ -142,11 +163,17 @@ const sidebars: SidebarsConfig = {
     {
       type: "category",
       label: "Common",
+      link: {
+        type: "generated-index"
+      },
       items: ["common/java-install"],
     },
     {
       type: "category",
       label: "PaperMC",
+      link: {
+        type: "generated-index"
+      },
       items: ["papermc/downloads-api", "papermc/assets", "papermc/contact"],
     },
   ],

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -28,6 +28,7 @@ const config: Config = {
   projectName: "docs",
   trailingSlash: false,
   noIndex: isPreview,
+  baseUrlIssueBanner: false,
 
   webpack: {
     jsLoader: (isServer) => ({

--- a/src/theme/DocBreadcrumbs/index.tsx
+++ b/src/theme/DocBreadcrumbs/index.tsx
@@ -1,0 +1,103 @@
+import React, {type ReactNode} from 'react';
+import {
+  ThemeClassNames,
+  useSidebarBreadcrumbs,
+  useHomePageRoute,
+} from '@docusaurus/theme-common';
+import styles from './styles.module.css';
+import clsx from 'clsx';
+import Link from '@docusaurus/Link';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
+// TODO move to design system folder
+function BreadcrumbsItemLink({
+  children,
+  href,
+}: {
+  children: ReactNode;
+  href?: string;
+}): JSX.Element {
+  const className = 'breadcrumbs__link';
+  return href ? (
+    <Link className={className} href={href} itemProp="item">
+      <span itemProp="name">{children}</span>
+    </Link>
+  ) : (
+    <span className={className} itemProp="item name">
+      {children}
+    </span>
+  );
+}
+
+// TODO move to design system folder
+function BreadcrumbsItem({
+  children,
+  active,
+  index,
+}: {
+  children: ReactNode;
+  active?: boolean;
+  index: number;
+}): JSX.Element {
+  return (
+    <li
+      itemScope
+      itemProp="itemListElement"
+      itemType="https://schema.org/ListItem"
+      className={clsx('breadcrumbs__item', {
+        'breadcrumbs__item--active': active,
+      })}>
+      {children}
+      <meta itemProp="position" content={String(index + 1)} />
+    </li>
+  );
+}
+
+function HomeBreadcrumbItem() {
+  const homeHref = useBaseUrl('/');
+  return (
+    <li className="breadcrumbs__item">
+      <Link
+        className={clsx('breadcrumbs__link', styles.breadcrumbsItemLink)}
+        href={homeHref}>
+        🏠
+      </Link>
+    </li>
+  );
+}
+
+export default function DocBreadcrumbs(): JSX.Element | null {
+  const breadcrumbs = useSidebarBreadcrumbs();
+  const homePageRoute = useHomePageRoute();
+
+  if (!breadcrumbs) {
+    return null;
+  }
+
+  return (
+    <nav
+      className={clsx(
+        ThemeClassNames.docs.docBreadcrumbs,
+        styles.breadcrumbsContainer,
+      )}
+      aria-label="breadcrumbs">
+      <ul
+        className="breadcrumbs"
+        itemScope
+        itemType="https://schema.org/BreadcrumbList">
+        {homePageRoute && <HomeBreadcrumbItem />}
+        {breadcrumbs.map((item, idx) => (
+          <BreadcrumbsItem
+            key={idx}
+            active={idx === breadcrumbs.length - 1}
+            index={idx}>
+            <BreadcrumbsItemLink
+              href={item.href}> {/* papermc - breadcrumb links on all pages, even current */}
+              {item.label}
+            </BreadcrumbsItemLink>
+          </BreadcrumbsItem>
+        ))}
+      </ul>
+    </nav>
+  );
+}

--- a/src/theme/DocBreadcrumbs/index.tsx
+++ b/src/theme/DocBreadcrumbs/index.tsx
@@ -1,13 +1,9 @@
-import React, {type ReactNode} from 'react';
-import {
-  ThemeClassNames,
-  useSidebarBreadcrumbs,
-  useHomePageRoute,
-} from '@docusaurus/theme-common';
-import styles from './styles.module.css';
-import clsx from 'clsx';
-import Link from '@docusaurus/Link';
-import useBaseUrl from '@docusaurus/useBaseUrl';
+import React, { type ReactNode } from "react";
+import { ThemeClassNames, useSidebarBreadcrumbs, useHomePageRoute } from "@docusaurus/theme-common";
+import styles from "./styles.module.css";
+import clsx from "clsx";
+import Link from "@docusaurus/Link";
+import useBaseUrl from "@docusaurus/useBaseUrl";
 
 // TODO move to design system folder
 function BreadcrumbsItemLink({
@@ -17,7 +13,7 @@ function BreadcrumbsItemLink({
   children: ReactNode;
   href?: string;
 }): JSX.Element {
-  const className = 'breadcrumbs__link';
+  const className = "breadcrumbs__link";
   return href ? (
     <Link className={className} href={href} itemProp="item">
       <span itemProp="name">{children}</span>
@@ -44,9 +40,10 @@ function BreadcrumbsItem({
       itemScope
       itemProp="itemListElement"
       itemType="https://schema.org/ListItem"
-      className={clsx('breadcrumbs__item', {
-        'breadcrumbs__item--active': active,
-      })}>
+      className={clsx("breadcrumbs__item", {
+        "breadcrumbs__item--active": active,
+      })}
+    >
       {children}
       <meta itemProp="position" content={String(index + 1)} />
     </li>
@@ -54,12 +51,10 @@ function BreadcrumbsItem({
 }
 
 function HomeBreadcrumbItem() {
-  const homeHref = useBaseUrl('/');
+  const homeHref = useBaseUrl("/");
   return (
     <li className="breadcrumbs__item">
-      <Link
-        className={clsx('breadcrumbs__link', styles.breadcrumbsItemLink)}
-        href={homeHref}>
+      <Link className={clsx("breadcrumbs__link", styles.breadcrumbsItemLink)} href={homeHref}>
         🏠
       </Link>
     </li>
@@ -76,25 +71,14 @@ export default function DocBreadcrumbs(): JSX.Element | null {
 
   return (
     <nav
-      className={clsx(
-        ThemeClassNames.docs.docBreadcrumbs,
-        styles.breadcrumbsContainer,
-      )}
-      aria-label="breadcrumbs">
-      <ul
-        className="breadcrumbs"
-        itemScope
-        itemType="https://schema.org/BreadcrumbList">
+      className={clsx(ThemeClassNames.docs.docBreadcrumbs, styles.breadcrumbsContainer)}
+      aria-label="breadcrumbs"
+    >
+      <ul className="breadcrumbs" itemScope itemType="https://schema.org/BreadcrumbList">
         {homePageRoute && <HomeBreadcrumbItem />}
         {breadcrumbs.map((item, idx) => (
-          <BreadcrumbsItem
-            key={idx}
-            active={idx === breadcrumbs.length - 1}
-            index={idx}>
-            <BreadcrumbsItemLink
-              href={item.href}> {/* papermc - breadcrumb links on all pages, even current */}
-              {item.label}
-            </BreadcrumbsItemLink>
+          <BreadcrumbsItem key={idx} active={idx === breadcrumbs.length - 1} index={idx}>
+            <BreadcrumbsItemLink href={item.href}> {item.label}</BreadcrumbsItemLink>
           </BreadcrumbsItem>
         ))}
       </ul>

--- a/src/theme/DocBreadcrumbs/styles.module.css
+++ b/src/theme/DocBreadcrumbs/styles.module.css
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+.breadcrumbsContainer {
+  --ifm-breadcrumb-size-multiplier: 0.8;
+  margin-bottom: 0.8rem;
+}

--- a/src/theme/DocBreadcrumbs/styles.module.css
+++ b/src/theme/DocBreadcrumbs/styles.module.css
@@ -1,10 +1,3 @@
-/**
- * Copyright (c) Facebook, Inc. and its affiliates.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 .breadcrumbsContainer {
   --ifm-breadcrumb-size-multiplier: 0.8;
   margin-bottom: 0.8rem;


### PR DESCRIPTION
Fixes an issue @MiniDigger noticed with google crying about invalid breadcrumbs.

This is intentional on the end of Docusaurus, ref https://togithub.com/facebook/docusaurus/pull/6932. Possibly a better solution is just to remove the last breadcrumb. I'm not sure, as there is good rationale provided there. 