### PR TITLE
Removed Event interface from custom velocity event example

### DIFF
--- a/docs/velocity/developers/api/event.md
+++ b/docs/velocity/developers/api/event.md
@@ -174,7 +174,7 @@ First we need to create a class for our event. In this tutorial we'll assume you
 messaging plugin, and thus use a `PrivateMessageEvent`. Most of this part is boilerplate.
 
 ```java
-public class PrivateMessageEvent implements Event {
+public class PrivateMessageEvent {
 
   private final Player sender;
   private final Player recipient;


### PR DESCRIPTION
Actually the example contradicts itself by saying `You'll notice that your events don't need to extend or implement anything. They just work.` being that the example implements an interface and the `Event` interface never existed and confuses many people thinking that they have to implement this interface