### PR TITLE
clarify auto save intervals

### DIFF
--- a/docs/paper/reference/paper-global-configuration.md
+++ b/docs/paper/reference/paper-global-configuration.md
@@ -86,14 +86,14 @@ function itself. For per-world configuration, see the
 ### player-auto-save-rate
 
 - **default**: -1
-- **description**: Set how often players should be saved. A value of -1 means it will pick a
-  recommended value for you.
+- **description**: How often player data should be saved in ticks. A value of `-1` will use
+  `ticks-per.autosave` in `bukkit.yml`.
 
 ### max-player-auto-save-per-tick
 
 - **default**: -1
-- **description**: How many players should be saved at most in a single tick. A value of -1 means it
-  will pick a recommended value for you.
+- **description**: How many players should be saved at most in a single tick. A value of `-1` will
+  set a recommended value based on `player-auto-save-rate`.
 
 ### save-empty-scoreboard-teams
 

--- a/docs/paper/reference/paper-per-world-configuration.md
+++ b/docs/paper/reference/paper-per-world-configuration.md
@@ -389,9 +389,9 @@ updates or even permanently if issues are found.
 ### auto-save-interval
 
 - **default**: -1
-- **note**: Default value instructs the world to use Bukkit's default.
-- **description**: Instructs this world to use a specific value for auto-save instead of bukkit's
-  global value.
+- **description**: Configures the world saving interval in ticks. Overrides `ticks-per.autosave` in
+  `bukkit.yml` for this world.
+- **note**: `-1` will use the global `ticks-per.autosave` in `bukkit.yml`.
 
 ### game-mechanics
 


### PR DESCRIPTION
Was missing units (ticks) and had incorrect info about the default behaviour of `player-auto-save-rate`. Admittedly though, the default behaviour does seem weird