### PR TITLE
Clarify navigation by marking current sidebar page with activity bar

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -109,12 +109,12 @@ html[data-theme="dark"] {
   padding: 0;
 }
 
-.menu__link:not(.menu__link--sublist) {
-  border-left-width: 4px;
-  border-left-style: solid;
-  border-left-color: transparent;
-}
-
 .menu__link--active:not(.menu__link--sublist) {
+  --size: 4px;
+
+  border-left-width: var(--size);
+  border-left-style: solid;
   border-left-color: var(--ifm-menu-color-active);
+  /* prevent text wrapping changes by shifting text to match new border */
+  padding-left: calc(var(--ifm-menu-link-padding-horizontal) - var(--size));
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -108,3 +108,13 @@ html[data-theme="dark"] {
   position: static;
   padding: 0;
 }
+
+.menu__link:not(.menu__link--sublist) {
+  border-left-width: 4px;
+  border-left-style: solid;
+  border-left-color: transparent;
+}
+
+.menu__link--active:not(.menu__link--sublist) {
+  border-left-color: var(--ifm-menu-color-active);
+}


### PR DESCRIPTION
I'm not quite sure I like the look of this right now, especially as it pushes the actual text on the sidebar over a bit. This was to prevent word wrapping changes when selecting a sidebar item. I'm not sure that it's the correct way to do that. There might be something better.

unwanted behaviour:

https://user-images.githubusercontent.com/76139600/172642360-e0221129-5381-4cd4-8d05-74d24e430702.mov


