### PR TITLE
Fix Gradle Groovy DSL config for Velocity development

### DIFF
--- a/docs/velocity/dev/getting-started/creating-your-first-plugin.md
+++ b/docs/velocity/dev/getting-started/creating-your-first-plugin.md
@@ -105,13 +105,13 @@ dependencies {
 ```groovy name="build.gradle"
 repositories {
     maven {
-        name 'papermc'
-        url 'https://repo.papermc.io/repository/maven-public/'
+        name = 'papermc'
+        url = 'https://repo.papermc.io/repository/maven-public/'
     }
 }
 
 dependencies {
-    compile 'com.velocitypowered:velocity-api:3.1.1'
+    compileOnly 'com.velocitypowered:velocity-api:3.1.1'
     annotationProcessor 'com.velocitypowered:velocity-api:3.1.1'
 }
 ```


### PR DESCRIPTION
Got stuck for a bit trying to set up a new Velocity plugin, it looks like it's currently not valid for the Groovy DSL.