### PR TITLE
Document the paper system properties

### DIFF
--- a/config/sidebar.paper.ts
+++ b/config/sidebar.paper.ts
@@ -46,7 +46,11 @@ const paper: SidebarsConfig = {
             type: "generated-index",
             slug: "/cat/admin/reference",
           },
-          items: ["admin/reference/global-configuration", "admin/reference/world-configuration"],
+          items: [
+            "admin/reference/global-configuration",
+            "admin/reference/world-configuration",
+            "admin/reference/system-properties",
+          ],
         },
       ],
     },

--- a/docs/paper/admin/reference/system-properties.md
+++ b/docs/paper/admin/reference/system-properties.md
@@ -6,6 +6,13 @@ slug: /reference/system-properties
 
 These system properties can be set when you start your server allowing for the configuration of various settings.
 
+:::danger Danger Ahead
+
+Setting flags for the JVM can alter how it operates and the same goes for the paper server.
+If you are unsure about what a flag does, it is recommended that you **do not use it**.
+
+:::
+
 ## How they work
 
 System properties are set when you start your server. For example, if you are using a `.bat` or a `.sh` file to start your server, you can add the system properties to the file. For example:
@@ -41,7 +48,7 @@ Where a `-D` is used to set a system property, and the system property is `paper
 #### paper.disableChannelLimit:
 
 - **default**: `unset`
-- **description**: Disables the channel limit for the server.
+- **description**: Disables the plugin channel limit for the server. This will disable the limit of 128 plugin channels per player.
 
 #### net.kyori.adventure.text.warnWhenLegacyFormattingDetected:
 
@@ -111,7 +118,8 @@ Where a `-D` is used to set a system property, and the system property is `paper
 #### debug.rewriteForIde:
 
 - **default**: `unset`
-- **description**: Removes the NMS revision from the stack trace to allow for easier debugging in IDEs.
+- **description**: Removes the NMS revision from the stack trace to allow for easier debugging in IDEs. 
+It also remaps plugin CB calls to remove the version information.
 
 #### convertLegacySigns:
 
@@ -159,4 +167,32 @@ Where a `-D` is used to set a system property, and the system property is `paper
 - **default**: `4` but is capped at `number of cpus / 2`
 - **description**: Sets the maximum number of threads to use for chunk loading.
 
+#### io.papermc.paper.suppress.sout.nags:
 
+- **default**: `unset`
+- **description**: Suppresses the nag message about using System.out/System.err in a plugin.
+
+#### paper.strict-thread-checks:
+
+- **default**: `unset`
+- **description**: Overrides the status of the AsyncCatcher so that it will always throw an exception if it is not on the main thread.
+
+#### Paper.skipServerPropertiesComments:
+
+- **default**: `unset`
+- **description**: Skips the comments in the server.properties file.
+
+#### Paper.debugInvalidSkullProfiles:
+
+- **default**: `unset`
+- **description**: Enables debug logging for invalid skull profiles. It appends an exception to the log.
+
+#### paper.alwaysPrintWarningState:
+
+- **default**: `unset`
+- **description**: Always prints the warning state for the particular level.
+
+#### Paper.printStacktraceOnBadPluginClassAccess:
+
+- **default**: `unset`
+- **description**: Prints a stacktrace when a plugin attempts to access a class that is not a dependency of the plugin.

--- a/docs/paper/admin/reference/system-properties.md
+++ b/docs/paper/admin/reference/system-properties.md
@@ -28,7 +28,7 @@ Where a `-D` is used to set a system property, and the system property is `paper
 #### paper.playerconnection.keepalive:
 
 - **default**: `30`
-- **description**: Controls how long the player connection will wait before closing in seconds.
+- **description**: Controls how long the player connection will wait before closing when not receiving any keepalives, in seconds.
 
 #### paper.ticklist-excessive-delay-threshold:
 
@@ -52,8 +52,8 @@ Where a `-D` is used to set a system property, and the system property is `paper
 
 #### net.kyori.adventure.text.warnWhenLegacyFormattingDetected:
 
-- **default**: `true`
-- **description**: Enables or disables the warning when legacy formatting is detected.
+- **default**: `false`
+- **description**: Enables or disables the warning when legacy formatting is detected in a chat component.
 
 #### Paper.DisableClassPrioritization:
 

--- a/docs/paper/admin/reference/system-properties.md
+++ b/docs/paper/admin/reference/system-properties.md
@@ -95,11 +95,6 @@ Where a `-D` is used to set a system property, and the system property is `paper
 - **default**: `unset`
 - **description**: Ignores the world data version when loading a world. This is not recommended and will likely cause issues.
 
-#### Paper.allowAsyncChunksSingleCore:
-
-- **default**: `unset`
-- **description**: Allows async chunk loading on single core systems.
-
 #### debug.entities:
 
 - **default**: `unset`
@@ -147,11 +142,6 @@ It also remaps plugin CB calls to remove the version information.
 - **default**: `Minecraft world version + 1`
 - **description**: If you are expecting to convert a large number of chunks you might consider setting this to only convert from a point onwards.
 
-#### paper.maxChunkThreads:
-
-- **default**: `4`
-- **description**: Sets the maximum number of threads to use for chunk loading. You cannot use more than half of the available cores.
-
 #### Paper.WorkerThreadCount:
 
 - **default**: `8` or `number of cpus - 2`. Whichever is lower
@@ -161,11 +151,6 @@ It also remaps plugin CB calls to remove the version information.
 
 - **default**: `750`
 - **description**: Splits tile entities into multiple packets if there are more than this many.
-
-#### paper.maxChunkThreads:
-
-- **default**: `4` but is capped at `number of cpus / 2`
-- **description**: Sets the maximum number of threads to use for chunk loading.
 
 #### io.papermc.paper.suppress.sout.nags:
 

--- a/docs/paper/admin/reference/system-properties.md
+++ b/docs/paper/admin/reference/system-properties.md
@@ -23,6 +23,13 @@ java -Dpaper.log-level=FINE -jar paper.jar
 
 Where a `-D` is used to set a system property, and the system property is `paper.log-level` with a value of `FINE`. Otherwise, just add them to the start command
 
+:::info
+
+Some of the paper system properties require have `.`'s in them. When using Windows Powershell, these will require wrapping in quotes.
+i.e. `"-Dpaper.log-level=FINE"`
+
+:::
+
 ## List of System Properties
 
 #### paper.playerconnection.keepalive:

--- a/docs/paper/admin/reference/system-properties.md
+++ b/docs/paper/admin/reference/system-properties.md
@@ -1,0 +1,162 @@
+---
+slug: /reference/system-properties
+---
+
+# Paper System Properties 
+
+These system properties can be set when you start your server allowing for the configuration of various settings.
+
+## How they work
+
+System properties are set when you start your server. For example, if you are using a `.bat` or a `.sh` file to start your server, you can add the system properties to the file. For example:
+
+```bash
+java -Dpaper.log-level=FINE -jar paper.jar
+```
+
+Where a `-D` is used to set a system property, and the system property is `paper.log-level` with a value of `FINE`. Otherwise, just add them to the start command
+
+## List of System Properties
+
+#### paper.playerconnection.keepalive:
+
+- **default**: `30`
+- **description**: Controls how long the player connection will wait before closing in seconds.
+
+#### paper.ticklist-excessive-delay-threshold:
+
+- **default**: `60`
+- **description**: Sets the excessive tick delay to the specified number of seconds.
+
+#### timings.bypassMax:
+
+- **default**: `unset`
+- **description**: Allows for bypassing the max number of frames to send to the Aikar's Timings API. Setting this will not permit bypassing the limit unless the API is configured to allow it.
+
+#### LetMeReload:
+
+- **default**: `unset`
+- **description**: Overrides the need to send confirmation message when using the `/reload` command.
+
+#### paper.disableChannelLimit:
+
+- **default**: `unset`
+- **description**: Disables the channel limit for the server.
+
+#### net.kyori.adventure.text.warnWhenLegacyFormattingDetected:
+
+- **default**: `true`
+- **description**: Enables or disables the warning when legacy formatting is detected.
+
+#### Paper.DisableClassPrioritization:
+
+- **default**: `unset`
+- **description**: Disables the class prioritization system - mostly an issue when failing to relocate or shade properly.
+
+#### Paper.disableFlushConsolidate:
+
+- **default**: `unset`
+- **description**: Disables the netty flush consolidation system.
+
+#### Paper.debugDynamicMissingKeys:
+
+- **default**: `unset`
+- **description**: Enables debug logging for missing keys in NBT objects.
+
+#### disable.watchdog:
+
+- **default**: `unset`
+- **description**: Disables the watchdog warning system.
+
+#### paper.explicit-flush:
+
+- **default**: `unset`
+- **description**: Enables explicit flushing of the network channel.
+
+#### Paper.enable-sync-chunk-writes:
+
+- **default**: `unset`
+- **description**: Syncs writes on each write call. This has a performance impact, particularly on hard drives.
+
+#### paper.debug-sync-loads:
+
+- **default**: `unset`
+- **description**: Enables debug logging for sync chunk loads.
+
+#### Paper.ignoreWorldDataVersion:
+
+- **default**: `unset`
+- **description**: Ignores the world data version when loading a world. This is not recommended and will likely cause issues.
+
+#### Paper.allowAsyncChunksSingleCore:
+
+- **default**: `unset`
+- **description**: Allows async chunk loading on single core systems.
+
+#### debug.entities:
+
+- **default**: `unset`
+- **description**: Enables debug log messages for entity information.
+
+#### Paper.bypassHostCheck:
+
+- **default**: `unset`
+- **description**: Bypasses the host pattern matching attempt for the client when connecting to the server.
+
+#### paper.ticklist-warn-on-excessive-delay:
+
+- **default**: `unset`
+- **description**: Enables the warning when a tick list is scheduled with an excessive delay.
+
+#### debug.rewriteForIde:
+
+- **default**: `unset`
+- **description**: Removes the NMS revision from the stack trace to allow for easier debugging in IDEs.
+
+#### convertLegacySigns:
+
+- **default**: `unset`
+- **description**: Converts legacy signs to the new format.
+
+#### paper.maxCustomChannelName:
+
+- **default**: `64`
+- **description**: Sets the largest size that a plugin channel can be.
+
+#### Paper.maxSignLength:
+
+- **default**: `80`
+- **description**: Sets the maximum line length for signs.
+
+#### Paper.FilterThreshhold:
+
+- **default**: `8192`
+- **min**: `8192`
+- **description**: Sets the maximum size of a packet to be filtered.
+
+#### Paper.minPrecachedDatafixVersion:
+
+- **default**: `Minecraft world version + 1`
+- **description**: If you are expecting to convert a large number of chunks you might consider setting this to only convert from a point onwards.
+
+#### paper.maxChunkThreads:
+
+- **default**: `4`
+- **description**: Sets the maximum number of threads to use for chunk loading. You cannot use more than half of the available cores.
+
+#### Paper.WorkerThreadCount:
+
+- **default**: `8` or `number of cpus - 2`. Whichever is lower
+- **description**: Sets the number of worker threads to use for chunk loading.
+
+#### Paper.excessiveTELimit:
+
+- **default**: `750`
+- **description**: Splits tile entities into multiple packets if there are more than this many.
+
+#### paper.maxChunkThreads:
+
+- **default**: `4` but is capped at `number of cpus / 2`
+- **description**: Sets the maximum number of threads to use for chunk loading.
+
+

--- a/docs/paper/admin/reference/system-properties.md
+++ b/docs/paper/admin/reference/system-properties.md
@@ -21,12 +21,18 @@ System properties are set when you start your server. For example, if you are us
 java -Dpaper.log-level=FINE -jar paper.jar
 ```
 
-Where a `-D` is used to set a system property, and the system property is `paper.log-level` with a value of `FINE`. Otherwise, just add them to the start command
-
 :::info
 
 Some of the paper system properties require have `.`'s in them. When using Windows Powershell, these will require wrapping in quotes.
 i.e. `"-Dpaper.log-level=FINE"`
+
+:::
+
+Where a `-D` is used to set a system property, and the system property is `paper.log-level` with a value of `FINE`. Otherwise, just add them to the start command
+
+:::note
+
+Where a system property is stated as `unset`, setting it as `true` will work to enable it.
 
 :::
 
@@ -183,3 +189,8 @@ It also remaps plugin CB calls to remove the version information.
 
 - **default**: `unset`
 - **description**: Prints a stacktrace when a plugin attempts to access a class that is not a dependency of the plugin.
+
+#### Paper.parseYamlCommentsByDefault:
+
+- **default**: `true`
+- **description**: Sets whether to parse comments in YAML files by default.

--- a/docs/paper/admin/reference/system-properties.md
+++ b/docs/paper/admin/reference/system-properties.md
@@ -8,7 +8,7 @@ These system properties can be set when you start your server allowing for the c
 
 :::danger Danger Ahead
 
-Setting flags for the JVM can alter how it operates and the same goes for the paper server.
+Setting flags for the JVM can alter how it operates and the same goes for the Paper server.
 If you are unsure about what a flag does, it is recommended that you **do not use it**.
 
 :::
@@ -30,20 +30,15 @@ Where a `-D` is used to set a system property, and the system property is `paper
 - **default**: `30`
 - **description**: Controls how long the player connection will wait before closing when not receiving any keepalives, in seconds.
 
-#### paper.ticklist-excessive-delay-threshold:
-
-- **default**: `60`
-- **description**: Sets the excessive tick delay to the specified number of seconds.
-
 #### timings.bypassMax:
 
 - **default**: `unset`
-- **description**: Allows for bypassing the max number of frames to send to the Aikar's Timings API. Setting this will not permit bypassing the limit unless the API is configured to allow it.
+- **description**: Allows for bypassing the max amount of data to send to the Aikar's Timings API. Setting this will not permit bypassing the limit unless the API is configured to allow it.
 
 #### LetMeReload:
 
 - **default**: `unset`
-- **description**: Overrides the need to send confirmation message when using the `/reload` command.
+- **description**: This disables the reload confirmation message when using the `/reload` command.
 
 #### paper.disableChannelLimit:
 
@@ -124,7 +119,7 @@ It also remaps plugin CB calls to remove the version information.
 #### paper.maxCustomChannelName:
 
 - **default**: `64`
-- **description**: Sets the largest size that a plugin channel can be.
+- **description**: Sets the largest size that a plugin channel name can take.
 
 #### Paper.maxSignLength:
 
@@ -160,7 +155,7 @@ It also remaps plugin CB calls to remove the version information.
 #### paper.strict-thread-checks:
 
 - **default**: `unset`
-- **description**: Overrides the status of the AsyncCatcher so that it will always throw an exception if it is not on the main thread.
+- **description**: This sets the status of the AsyncCatcher so that it will always log an error if code is not run on the main thread.
 
 #### Paper.skipServerPropertiesComments:
 
@@ -170,7 +165,7 @@ It also remaps plugin CB calls to remove the version information.
 #### Paper.debugInvalidSkullProfiles:
 
 - **default**: `unset`
-- **description**: Enables debug logging for invalid skull profiles. It appends an exception to the log.
+- **description**: Enables debug logging for invalid skull profiles. This logs any invalid skulls in the world with the appropriate location information.
 
 #### paper.alwaysPrintWarningState:
 


### PR DESCRIPTION
As outlined: https://github.com/PaperMC/docs/issues/23 the documentation of paper system properties has been widely just cat telling people in paper-help :)

I have omitted some of the properties outlined in those issues as a lot of them were removed in 1.14. The ones removed in the last two versions I have kept. Any more which I have missed or formatting issues let me know