### PR TITLE
Add a basic development guide

### DIFF
--- a/config/sidebar.paper.ts
+++ b/config/sidebar.paper.ts
@@ -63,10 +63,8 @@ const paper: SidebarsConfig = {
         id: "dev/README",
       },
       items: [
-        {
-          type: "ref",
-          id: "dev/README",
-        },
+        "dev/getting-started/project-setup",
+        "dev/getting-started/plugin-yml",
       ],
     },
   ],

--- a/docs/paper/dev/getting-started/plugin-yml.md
+++ b/docs/paper/dev/getting-started/plugin-yml.md
@@ -151,7 +151,7 @@ commands:
 - The __description__ is the description of the command. This gives a brief description of what the command does.
 - The __usage__ is the usage of the command. This is what will be displayed when the player uses `/help <command>`.
 - The __aliases__ are a list of aliases that the command can be used with. This is useful for shortening the command.
-- __permission__ is the permission node that the player needs to use the command.
+- __permission__ is the permission node that the player needs to use the command. Note: Players will only see commands they have permission to use.
 - __permission-message__ is the message that will be displayed when the player does not have permission to use the command.
 
 ## Dependencies:

--- a/docs/paper/dev/getting-started/plugin-yml.md
+++ b/docs/paper/dev/getting-started/plugin-yml.md
@@ -1,0 +1,188 @@
+---
+slug: /dev/plugin-yml
+---
+
+# Paper Plugin YML
+
+The plugin.yml file is the main configuration file for your plugin. 
+It contains information about your plugin, such as its name, version, and description. 
+It also contains information about the plugin's dependencies, permissions, and commands.
+
+The plugin.yml file is located in the `resources` directory of your project.
+```
+src
+└── main
+    ├── java
+    └── resources
+        └── plugin.yml
+```
+
+## Example
+
+Here is an example of a plugin.yml file:
+
+```yaml
+name: ExamplePlugin
+version: 1.0.0
+main: io.papermc.testplugin.ExamplePlugin
+description: An example plugin
+author: PaperMC
+website: https://papermc.io
+api-version: 1.19
+```
+
+## Fields
+
+:::note
+
+The fields in this section are not in any particular order. 
+If they have an asterisk (\*) next to them, that means they are required.
+
+:::
+
+### name*
+
+The name of your plugin. This is what will be displayed in the plugin list and warning messages.
+- `name: ExamplePlugin`
+
+### version*
+
+The current version of the plugin. 
+- `version: 1.0.0`
+
+### main*
+
+The main class of your plugin. This is the class that extends `JavaPlugin` and is the entry point to your plugin.
+- `main: io.papermc.testplugin.ExamplePlugin`
+
+This is the package path and class name of your main class.
+
+### description
+
+A short description of your plugin and what it does.
+- `description: An example plugin`
+
+### author / authors
+
+The author(s) of the plugin. This can be a single author or a list of authors.
+- `author: PaperMC`
+- `authors: [PaperMC, SpigotMC, Bukkit]`
+
+### website
+
+The website of the plugin. This is useful for linking to a GitHub repository or a plugin page.
+- `website: https://papermc.io`
+
+### api-version
+
+The version of the Paper API that your plugin is using. This doesn't include the minor version. 
+The valid versions are 1.12 - 1.19.
+- `api-version: 1.19`
+
+:::info
+
+If this is not specified, the plugin will be loaded as a legacy plugin and a warning will be printed to the console.
+
+:::
+
+### load
+
+This tells the server when to load the plugin. This can be `STARTUP` or `POSTWORLD`.
+- `load: STARTUP`
+
+### prefix
+
+The prefix of the plugin. This is what will be displayed in the log instead of the plugin name.
+- `prefix: EpicPaperMCHypePlugin`
+
+### libraries
+
+:::warning
+
+There is debate over whether this is against maven central's TOS. This may be removed in the future.
+
+:::
+
+This is a list of libraries that your plugin depends on. These libraries will be downloaded from the Maven repository and added to the classpath.
+This removes the need to shade or relocate the libraries.
+
+```yaml
+libraries:
+  - com.google.guava:guava:30.1.1-jre
+  - com.google.code.gson:gson:2.8.6
+```
+
+### permissions
+
+This is a list of permissions that your plugin uses. This is useful for plugins that use permissions to restrict access to certain features.
+```yaml
+permissions :
+  - permission.node:
+        description: "This is a permission node"
+        default: op
+        children:
+            - permission.node.child: true
+  - another.permission.node:
+        description: "This is another permission node"
+        default: not op
+```
+
+The description is the description of the permission node. This is what will be displayed in the permissions list.
+The default is the default value of the permission node. This can be `op`/`not op`, or `true`/`false`. This defaults to `op`.
+Each permission node can have children. When set to `true` it will inherit the parent permission.
+
+## Commands
+
+This is a list of commands that your plugin uses. This is useful for plugins that use commands to provide features.
+```yaml
+commands:
+  - command:
+        description: "This is a command"
+        usage: "/command <arg>"
+        aliases: [cmd, command]
+        permission: permission.node
+        permission-message: "You do not have permission to use this command"
+```
+
+- The __description__ is the description of the command. This gives a brief description of what the command does.
+- The __usage__ is the usage of the command. This is what will be displayed when the player uses `/help <command>`.
+- The __aliases__ are a list of aliases that the command can be used with. This is useful for shortening the command.
+- __permission__ is the permission node that the player needs to use the command.
+- __permission-message__ is the message that will be displayed when the player does not have permission to use the command.
+
+## Dependencies:
+
+:::note
+
+If a plugin is specified as a dependency, it will be loaded before your plugin.
+
+:::
+
+### depend
+
+A list of plugins that your plugin depends on to __load__. They are specified by their plugin name.
+
+:::info
+
+If the plugin is not found, your plugin will not load.
+
+:::
+
+- `depend: [Vault, WorldEdit]`
+
+### softdepend
+
+A list of plugins that your plugin depends on to have __full functionality__. They are specified by their plugin name.
+
+- `softdepend: [Vault, WorldEdit]`
+
+### loadbefore
+
+A list of plugins that your plugin should be loaded __before__. They are specified by their plugin name.
+This is useful if you want to load your plugin before another plugin for the other plugin to use your plugin's API.
+
+- `loadbefore: [Vault, FactionsUUID]`
+
+
+
+

--- a/docs/paper/dev/getting-started/plugin-yml.md
+++ b/docs/paper/dev/getting-started/plugin-yml.md
@@ -10,11 +10,12 @@ It also contains information about the plugin's dependencies, permissions, and c
 
 The plugin.yml file is located in the `resources` directory of your project.
 ```
-src
-└── main
-    ├── java
-    └── resources
-        └── plugin.yml
+example-plugin
+└── src
+    └── main
+        ├── java
+        └── resources
+            └── plugin.yml
 ```
 
 ## Example
@@ -42,7 +43,7 @@ If they have an asterisk (\*) next to them, that means they are required.
 
 ### name*
 
-The name of your plugin. This is what will be displayed in the plugin list and warning messages.
+The name of your plugin. This is what will be displayed in the plugin list and log messages.
 - `name: ExamplePlugin`
 
 ### version*
@@ -75,8 +76,9 @@ The website of the plugin. This is useful for linking to a GitHub repository or 
 
 ### api-version
 
-The version of the Paper API that your plugin is using. This doesn't include the minor version. 
-The valid versions are 1.12 - 1.19.
+The version of the Paper API that your plugin is using. This doesn't include the minor version.
+Servers with a version lower than the version specified here will refuse to load the plugin.
+The valid versions are 1.13 - 1.19.
 - `api-version: 1.19`
 
 :::info
@@ -103,8 +105,8 @@ There is debate over whether this is against maven central's TOS. This may be re
 
 :::
 
-This is a list of libraries that your plugin depends on. These libraries will be downloaded from the Maven repository and added to the classpath.
-This removes the need to shade or relocate the libraries.
+This is a list of libraries that your plugin depends on. These libraries will be downloaded from the Maven central repository and added to the classpath.
+This removes the need to shade and relocate the libraries.
 
 ```yaml
 libraries:

--- a/docs/paper/dev/getting-started/plugin-yml.md
+++ b/docs/paper/dev/getting-started/plugin-yml.md
@@ -11,6 +11,8 @@ It also contains information about the plugin's dependencies, permissions, and c
 The plugin.yml file is located in the `resources` directory of your project.
 ```
 example-plugin
+├── build.gradle.kts
+├── settings.gradle.kts
 └── src
     └── main
         ├── java

--- a/docs/paper/dev/getting-started/project-setup.md
+++ b/docs/paper/dev/getting-started/project-setup.md
@@ -4,7 +4,7 @@ slug: /dev/project-setup
 
 # Paper Project Setup
 
-As the Paper team primarily uses IntelliJ IDEA, this guide will be focused on that IDE. 
+As the Paper team primarily uses [IntelliJ IDEA](https://www.jetbrains.com/idea/), this guide will be focused on that IDE. 
 However, the steps below should be applicable to other IDEs as well, with some minor changes.
 
 
@@ -116,8 +116,16 @@ The `resources` directory is where you will place your plugin's `plugin.yml` fil
 You should now have a project set up with Paper as a dependency.
 All you have left to do now is to compile your plugin and run it on a paper server.
 
+:::note
+
+If you want to streamline the process of testing a plugin, you can use the [Run-Paper](https://github.com/jpenilla/run-paper) Gradle task.
+It will automatically download a paper server and run it for you.
+
+:::
+
 :::info
     
 If you are using IntelliJ, you can use the Gradle GUI `Build` menu to compile your plugin - found on the top right of your IDE.
+The output jar of your plugin will be in the `build/libs` directory.
 
 :::

--- a/docs/paper/dev/getting-started/project-setup.md
+++ b/docs/paper/dev/getting-started/project-setup.md
@@ -124,12 +124,12 @@ The `resources` directory is where you will place your plugin's `plugin.yml` fil
 ### Conclusion
 
 You should now have a project set up with Paper as a dependency.
-All you have left to do now is to compile your plugin and run it on a paper server.
+All you have left to do now is to compile your plugin and run it on a Paper server.
 
 :::note
 
 If you want to streamline the process of testing a plugin, you can use the [Run-Paper](https://github.com/jpenilla/run-paper) Gradle task.
-It will automatically download a paper server and run it for you.
+It will automatically download a Paper server and run it for you.
 
 :::
 

--- a/docs/paper/dev/getting-started/project-setup.md
+++ b/docs/paper/dev/getting-started/project-setup.md
@@ -23,9 +23,7 @@ To add Paper as a dependency, you will need to add the Paper repository to your 
 ```kotlin
 repositories {
     mavenCentral()
-    maven {
-        url = uri("https://repo.papermc.io/repository/maven-public/")
-    }
+    maven("https://repo.papermc.io/repository/maven-public/")
 }
 
 dependencies {
@@ -45,6 +43,12 @@ To see the versions of Paper you want to use, visit our [Downloads](https://www.
 
 ### Setting up the `src` directory
 
+:::note
+
+If your project creates a `src` directory automatically, you can skip this step.
+
+:::
+
 To set up the `src` directory, you will need to create a new directory called `src` and then create a new directory called `main` inside of it.
 Inside of `main`, create two new directories called `java` and `resources`.
 
@@ -53,6 +57,8 @@ It should look like this:
 ```
 ...
 example-plugin
+├── build.gradle.kts
+├── settings.gradle.kts
 └── src
     └── main
         ├── java
@@ -68,6 +74,8 @@ For this example, we will create three packages called `io.papermc.testplugin` a
 ```
 ...
 example-plugin
+├── build.gradle.kts
+├── settings.gradle.kts
 └── src
     └── main
         ├── java

--- a/docs/paper/dev/getting-started/project-setup.md
+++ b/docs/paper/dev/getting-started/project-setup.md
@@ -1,0 +1,123 @@
+---
+slug: /dev/project-setup
+---
+
+# Paper Project Setup
+
+As the Paper team primarily uses IntelliJ IDEA, this guide will be focused on that IDE. 
+However, the steps below should be applicable to other IDEs as well, with some minor changes.
+
+
+### Creating a new project
+
+Open your IDE and select the option to create a new project. 
+In Intellij, you will get the option to select the type of project you want to create. 
+Select `Gradle - Kotlin DSL` and click `Create`.
+
+You will land into the `build.gradle.kts` file where you can add your dependencies.
+
+### Adding Paper as a dependency
+
+To add Paper as a dependency, you will need to add the Paper repository to your `build.gradle.kts` file as well as the dependency itself.
+
+```kotlin
+repositories {
+    mavenCentral()
+    maven {
+        url = uri("https://repo.papermc.io/repository/maven-public/")
+    }
+}
+
+dependencies {
+    compileOnly("io.papermc.paper:paper-api:1.19.2-R0.1-SNAPSHOT")
+}
+
+java {
+    toolchain.languageVersion.set(JavaLanguageVersion.of(17))
+}
+```
+
+:::info
+
+To see the versions of Paper you want to use, visit our [Downloads](https://www.papermc.io/downloads) page.
+
+:::
+
+### Setting up the `src` directory
+
+To set up the `src` directory, you will need to create a new directory called `src` and then create a new directory called `main` inside of it.
+Inside of `main`, create two new directories called `java` and `resources`.
+
+It should look like this:
+
+```
+...
+src
+└── main
+    ├── java
+    └── resources
+...
+```
+
+### Setting up the `java` directory
+
+You will place your Java source files in the `java` directory. You first need to create some packages to organize your code.
+For this example, we will create three packages called `io.papermc.testplugin` and then create a class called `ExamplePlugin` inside of it.
+
+```
+...
+src
+└── main
+    ├── java
+    │   └── io
+    │       └── papermc
+    │           └── testplugin
+    │               └── ExamplePlugin.java
+    └── resources
+...
+```
+
+### The _main_ class
+
+The main class is the entry point to your plugin and will be the only class that extends `JavaPlugin` in your plugin. 
+This is an example of what your `ExamplePlugin` class could look like:
+
+```java
+package io.papermc.testplugin;
+
+import net.kyori.adventure.text.Component;
+import org.bukkit.Bukkit;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class ExamplePlugin extends JavaPlugin implements Listener {
+
+    @Override
+    public void onEnable() {
+        Bukkit.getPluginManager().registerEvents(this, this);
+    }
+
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        event.getPlayer().sendMessage(Component.text("Hello, " + event.getPlayer().getName() + "!"));
+    }
+
+}
+```
+
+### Setting up the `resources`
+
+The `resources` directory is where you will place your plugin's `plugin.yml` file. See the [Plugin YML](/paper/dev/plugin-yml) page for more information.
+
+### Conclusion
+
+You should now have a project set up with Paper as a dependency.
+All you have left to do now is to compile your plugin and run it on a paper server.
+
+:::info
+    
+If you are using IntelliJ, you can use the Gradle GUI `Build` menu to compile your plugin - found on the top right of your IDE.
+
+:::

--- a/docs/paper/dev/getting-started/project-setup.md
+++ b/docs/paper/dev/getting-started/project-setup.md
@@ -52,10 +52,11 @@ It should look like this:
 
 ```
 ...
-src
-└── main
-    ├── java
-    └── resources
+example-plugin
+└── src
+    └── main
+        ├── java
+        └── resources
 ...
 ```
 
@@ -66,14 +67,15 @@ For this example, we will create three packages called `io.papermc.testplugin` a
 
 ```
 ...
-src
-└── main
-    ├── java
-    │   └── io
-    │       └── papermc
-    │           └── testplugin
-    │               └── ExamplePlugin.java
-    └── resources
+example-plugin
+└── src
+    └── main
+        ├── java
+        │   └── io
+        │       └── papermc
+        │           └── testplugin
+        │               └── ExamplePlugin.java
+        └── resources
 ...
 ```
 


### PR DESCRIPTION
Adds a basic project setup for gradle as well as an outline of the `plugin.yml`. Although spigot already has one of these pages, with the potential for specific paper keys with Owen's PR and a hardfork soon, I deemed it proper to have a page here as well.