### PR TITLE
Fix `duplicate-uuid` section indention

### DIFF
--- a/docs/paper/admin/reference/world-configuration.md
+++ b/docs/paper/admin/reference/world-configuration.md
@@ -405,9 +405,9 @@ this list.
 - **default**: `false`
 - **description**: Whether to block players from changing the type of mob spawners with a spawn egg.
 
-### duplicate-uuid
+#### duplicate-uuid
 
-#### mode
+##### mode
 
 - **default**: `saferegen`
 
@@ -418,7 +418,7 @@ this list.
   - **`silent`**: Does nothing, not printing logs.
   - **`warn`**: Does nothing, printing logs.
 
-#### safe-regen-delete-range
+##### safe-regen-delete-range
 
 - **default**: `32`
 - **description**: If multiple entities with duplicate UUIDs are within this many blocks, saferegen


### PR DESCRIPTION
This was previously indented one level too few which lead to it being treated as on the same level as the actual parent `spawning` and as the parent section of the following, not directly related keys like `filter-nbt-data-from-spawn-eggs-and-related` or `iron-golems-can-spawn-in-air`.