### PR TITLE
fix: improve grammar in "Paper System Properties"

### DIFF
--- a/docs/paper/admin/reference/system-properties.md
+++ b/docs/paper/admin/reference/system-properties.md
@@ -23,7 +23,7 @@ java -Dpaper.log-level=FINE -jar paper.jar
 
 :::info
 
-Some of the paper system properties require have `.`'s in them. When using Windows Powershell, these will require wrapping in quotes.
+Some of the paper system properties contain a `.` character in their name. When using Windows Powershell, these will require wrapping in quotes.
 i.e. `"-Dpaper.log-level=FINE"`
 
 :::


### PR DESCRIPTION
In the "Paper System Properties" page, under the first "INFO" block, there is some awkward grammar when referring to the presence of `.` when using Windows PowerShell. This PR clarifies that grammar.