### PR TITLE
Update Velocity compatibility to Minecraft 1.19.3

### DIFF
--- a/docs/velocity/admin/reference/server-compatibility.md
+++ b/docs/velocity/admin/reference/server-compatibility.md
@@ -10,7 +10,7 @@ we can.
 
 ## Compatible game versions
 
-As of this writing, Velocity is compatible with Minecraft 1.7.2 through 1.19.2.
+As of this writing, Velocity is compatible with Minecraft 1.7.2 through 1.19.3.
 
 ## Vanilla setups
 


### PR DESCRIPTION
https://github.com/PaperMC/docs/pull/79: "*There is still no way to automatically update this value through the API as mentioned in the previous pull request*"

https://github.com/PaperMC/Velocity/pull/893 / https://github.com/PaperMC/Velocity/commit/b1fa9dc9538b19f4fe84fd42add212562068a367