### PR TITLE
Add missing values to nether configuration

### DIFF
--- a/docs/paper/admin/how-to/anti-xray.md
+++ b/docs/paper/admin/how-to/anti-xray.md
@@ -141,7 +141,9 @@ anticheat:
     - ancient_debris
     - nether_gold_ore
     - nether_quartz_ore
+    lava-obscures: false
     max-block-height: 128
+    replacement-blocks: []
     update-radius: 2
     use-permission: false
 ```

--- a/docs/paper/admin/how-to/anti-xray.md
+++ b/docs/paper/admin/how-to/anti-xray.md
@@ -251,6 +251,7 @@ anticheat:
     - nether_gold_ore
     - nether_quartz_ore
     - polished_blackstone_bricks
+    lava-obscures: false
     max-block-height: 128
     replacement-blocks:
     - basalt

--- a/docs/paper/admin/how-to/anti-xray.md
+++ b/docs/paper/admin/how-to/anti-xray.md
@@ -142,6 +142,8 @@ anticheat:
     - nether_gold_ore
     - nether_quartz_ore
     max-block-height: 128
+    update-radius: 2
+    use-permission: false
 ```
 
 </details>
@@ -255,6 +257,8 @@ anticheat:
     - netherrack
     - soul_sand
     - soul_soil
+    update-radius: 2
+    use-permission: false
 ```
 
 </details>

--- a/docs/paper/admin/how-to/anti-xray.md
+++ b/docs/paper/admin/how-to/anti-xray.md
@@ -135,6 +135,8 @@ Copy and paste into your `paper-world.yml` within your nether world folder. See 
 ```yml title="world_nether/paper-world.yml"
 anticheat:
   anti-xray:
+    enabled: true
+    engine-mode: 1
     hidden-blocks:
     - ancient_debris
     - nether_gold_ore
@@ -232,6 +234,8 @@ Copy and paste into your `paper-world.yml` within your nether world folder. See 
 ```yml title="world_nether/paper-world.yml"
 anticheat:
   anti-xray:
+    enabled: true
+    engine-mode: 2
     hidden-blocks:
     # See note about air and possible client performance issues above.
     - air


### PR DESCRIPTION
The recommended anti-xray config for the nether was missing the enabled and engine-mode values.