### PR TITLE
Change anti-xray world configuration headers

### DIFF
--- a/docs/paper/admin/how-to/anti-xray.md
+++ b/docs/paper/admin/how-to/anti-xray.md
@@ -78,7 +78,7 @@ formatting remains unchanged by using the "copy" button in the top right of each
 ### `engine-mode: 1`
 
 <details>
-  <summary>Overworld Configuration</summary>
+  <summary>Default World Configuration</summary>
 
 Replace the existing `anticheat.anti-xray` block in `paper-world-defaults.yml` with the following:
 
@@ -162,7 +162,7 @@ anticheat:
 ### `engine-mode: 2`
 
 <details>
-  <summary>Overworld Configuration</summary>
+  <summary>Default World Configuration</summary>
 
 Replace the existing `anticheat.anti-xray` block in `paper-world-defaults.yml` with the following:
 


### PR DESCRIPTION
This renamed the "Overworld Configuration" to default world since it's no longer the overworld config but a config for all worlds without an override.