### PR TITLE
Fixed errors in Event-API document

### DIFF
--- a/docs/paper/dev/api/event-api/event-listeners.md
+++ b/docs/paper/dev/api/event-api/event-listeners.md
@@ -111,7 +111,7 @@ public class ExampleListener implements Listener {
     }
 }
 ```
-**The BlockLockCheckEvent method and the PlayerLoginEvent method do not implement the Cancellable interface, but similar effects can still be achieved through the setResult (Result result) method.**
+**The BlockLockCheckEvent and PlayerLoginEvent types do not implement the Cancellable interface, but similar effects can still be achieved through the setResult (Result result) method.**
 :::warning
 
 It is important to consider that another plugin could have cancelled or changed the event before your plugin is called.

--- a/docs/paper/dev/api/event-api/event-listeners.md
+++ b/docs/paper/dev/api/event-api/event-listeners.md
@@ -111,7 +111,6 @@ public class ExampleListener implements Listener {
     }
 }
 ```
-**The BlockLockCheckEvent and PlayerLoginEvent types do not implement the Cancellable interface, but similar effects can still be achieved through the setResult (Result result) method.**
 :::warning
 
 It is important to consider that another plugin could have cancelled or changed the event before your plugin is called.
@@ -119,7 +118,7 @@ Always check the event before doing anything with it.
 
 :::
 
-The above example will cancel the event, meaning that the player will not be able to join the server.
+The above example will cancel the event, meaning that the Anvil will not cause damage.
 Once an event is cancelled, it will continue to call any other listeners for that event unless they add 
 `ignoreCancelled = true` to the `@EventHandler` annotation to ignore cancelled events.
 
@@ -127,8 +126,20 @@ Once an event is cancelled, it will continue to call any other listeners for tha
 public class ExampleListener implements Listener {
 
     @EventHandler(ignoreCancelled = true)
-    public void onPlayerJoin(PlayerJoinEvent event) {
+    public void onAnvilDamagedEvent(AnvilDamagedEvent event) {
         // ...
     }
 }
 ```
+## Set event result
+
+The results of some events can be modified, To change some behaviors. These events have method 'setResult' and internal enumeration class `Result`.
+    
+```java title="ExampleListener.java"
+public class ExampleListener implements Listener {
+
+    @EventHandler
+    public void onPlayerJoin(PlayerLoginEvent event) {
+        e.setResult(PlayerLoginEvent.Result.KICK_OTHER);//This means that the player cannot access the server for "other reasons"
+    }
+}


### PR DESCRIPTION
After actual measurement, in the new API (1.19.3-R0.1-SNAPSHOT), PlayerJoinEvent does not use the Cancellable interface described in the document. The code in the document is in. I think it should be changed and an alternative solution should be provided.