### PR TITLE
Improve warning background color in light mode

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1,6 +1,7 @@
 :root {
   --ifm-color-primary: #0240dc;
   --ifm-color-primary-dark: #033ed5;
+  --ifm-color-warning-contrast-background: #ffe39c;
 
   --ifm-code-font-size: 95%;
 


### PR DESCRIPTION
When in light mode the background color of an alert box does not really stand out like it does in dark mode.

Better light mode background from this PR:
![image](https://user-images.githubusercontent.com/5768781/218264176-81806ad0-f1f9-4f3d-ad65-2d268369f3ad.png)

Old light mode:
![Aikar's_Flags__PaperMC_Documentation_-_Chromium_2023-02-11_15-36-07](https://user-images.githubusercontent.com/5768781/218263753-6e9c4fe0-4d63-4a9d-bd69-43a187d67ec0.png)

(Dark mode as reference:
![Aikar's_Flags__PaperMC_Documentation_-_Chromium_2023-02-11_15-35-59](https://user-images.githubusercontent.com/5768781/218263759-d2f9178a-6054-4177-9868-731e9742d154.png))

