### PR TITLE
fix logo size and alignment

### DIFF
--- a/config/navbar.config.ts
+++ b/config/navbar.config.ts
@@ -5,8 +5,8 @@ const navbar: Omit<Navbar, "style" | "hideOnScroll"> = {
   logo: {
     src: "img/logo-marker-light.svg",
     srcDark: "img/logo-marker-dark.svg",
-    width: 130,
-    height: 32,
+    height: 42, // when changing here, also change css
+    width: 121,
     alt: "PaperMC Docs",
   },
   items: [

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -109,6 +109,14 @@ html[data-theme="dark"] {
 
 .navbar__logo {
   margin: 0;
+  height: unset;
+  display: flex;
+}
+
+.navbar__logo img {
+  height: 42px;
+  width: auto;
+  margin-top: 2px; /* simulated line height to align stuff */
 }
 
 .menu__link--active:not(.menu__link--sublist) {


### PR DESCRIPTION
supersedes #139 
looks like this:
![https://images-ext-1.discordapp.net/external/cNTsNpoJVkXZhAnWyKg_nSJQEXBmpsTLkwSIdK2_bj4/https/i.imgur.com/uDftuD9.png?width=656&height=676](https://images-ext-1.discordapp.net/external/cNTsNpoJVkXZhAnWyKg_nSJQEXBmpsTLkwSIdK2_bj4/https/i.imgur.com/uDftuD9.png?width=656&height=676)