### PR TITLE
Update Velocity compatibility to Minecraft 1.19.4

### DIFF
--- a/docs/velocity/admin/reference/server-compatibility.md
+++ b/docs/velocity/admin/reference/server-compatibility.md
@@ -10,7 +10,7 @@ we can.
 
 ## Compatible game versions
 
-As of this writing, Velocity is compatible with Minecraft 1.7.2 through 1.19.3.
+As of this writing, Velocity is compatible with Minecraft 1.7.2 through 1.19.4.
 
 ## Vanilla setups
 


### PR DESCRIPTION
https://github.com/PaperMC/docs/pull/79: _"There is still no way to automatically update this value through the API as mentioned in the previous pull request"_

![2023-03-14_11 23 39](https://user-images.githubusercontent.com/68704415/225072150-d3711373-0df3-46a2-b4b6-64937f680143.png)
