### PR TITLE
fix: navber fixes

### DIFF
--- a/config/navbar.config.ts
+++ b/config/navbar.config.ts
@@ -41,6 +41,11 @@ const navbar: Omit<Navbar, "style" | "hideOnScroll"> = {
           to: "/folia/admin",
           activeBaseRegex: "(\\/folia/)(?!dev)(.+)?",
         },
+        {
+          label: "Development",
+          to: "/folia/dev",
+          activeBaseRegex: "\\/folia\\/dev.*",
+        },
       ],
     },
     {


### PR DESCRIPTION
Fixed an issue where links to Folia's Development page were not being displayed in the navbar

<img width="231" alt="CleanShot 2023-04-06 at 09 21 40@2x" src="https://user-images.githubusercontent.com/127779256/230242114-7f7e576d-02ec-469e-b719-e216f5e9e53a.png">

<img width="315" alt="CleanShot 2023-04-06 at 09 21 51@2x" src="https://user-images.githubusercontent.com/127779256/230242133-c54f2767-94f9-41b3-a10b-d05cfa07c4ed.png">
