### PR TITLE
Change config table of contents to include all settings

### DIFF
--- a/docs/paper/admin/reference/global-configuration.md
+++ b/docs/paper/admin/reference/global-configuration.md
@@ -1,5 +1,6 @@
 ---
 slug: /reference/global-configuration
+toc_max_heading_level: 5
 keywords:
   - paper-global.yml
   - paper.yml

--- a/docs/paper/admin/reference/world-configuration.md
+++ b/docs/paper/admin/reference/world-configuration.md
@@ -1,5 +1,6 @@
 ---
 slug: /reference/world-configuration
+toc_max_heading_level: 5
 keywords:
   - paper-world-defaults.yml
   - paper-world.yml


### PR DESCRIPTION
Changes the maximum heading level for headings included in the table of content for both Paper config pages. This means that all config settings are now included in the sidebar on the right, in a layout somewhat similar to the config file itself.

The config pages are currently a bit unstructured and its hard to find the setting you are looking for and not all settings showing up in the sidebar isn't helping.

Downside to this is that it makes the table of content quite long. 

Before:
![chrome_deDG767GQO](https://user-images.githubusercontent.com/6106558/231031263-531e4b10-0f9e-4d7a-a206-15061e04b323.png)
After:
![chrome_AHIPkjg3Dk](https://user-images.githubusercontent.com/6106558/231031280-3de1f0ea-c622-4d0e-9c4a-8e53ae6e2502.png)
