### PR TITLE
Feature/chunk system

### DIFF
--- a/docs/paper/admin/reference/global-configuration.md
+++ b/docs/paper/admin/reference/global-configuration.md
@@ -94,7 +94,8 @@ function itself. For per-world configuration, see the
 
 - **default**: `-1`
 - **description**: Sets the number of threads to be used for parallel chunk generation. If any value below
-  zero is set, the server will determine the best number depending on the number of available CPU cores
+  zero is set, the server will determine the best number depending on the number of available CPU cores.
+  This is capped at a quarter of available processors and can be less for systems with very few processors.
   _(important: **not** threads i.e. Hyper-Threading doesn't count)_ the runtime.
 
 ## collisions

--- a/docs/paper/admin/reference/global-configuration.md
+++ b/docs/paper/admin/reference/global-configuration.md
@@ -96,7 +96,7 @@ function itself. For per-world configuration, see the
 - **description**: Sets the number of threads to be used for parallel chunk generation. If any value below
   zero is set, the server will determine the best number depending on the number of available CPU cores.
   This is capped at a quarter of available processors and can be less for systems with very few processors.
-  _(important: **not** threads i.e. Hyper-Threading doesn't count)_ the runtime.
+  _(Note: Hyper-Threaded threads **do not** count)_.
 
 ## collisions
 

--- a/docs/paper/admin/reference/global-configuration.md
+++ b/docs/paper/admin/reference/global-configuration.md
@@ -75,6 +75,28 @@ function itself. For per-world configuration, see the
 - **default**: `100.0`
 - **description**: The maximum number of chunks sent to an individual player within one second.
 
+## chunk-system
+
+### gen-parallelism
+
+- **default**: `default`
+- **description**: Sets whether the server should use parallel chunk generation. The `default` value
+  will be used as `true`. Possible options are `true`, `on` and `enable` to make the server use the
+  system and `false`, `off` or `disabled` to disable.
+
+### io-threads
+
+- **default**: `-1`
+- **description**: Sets the number of threads to be used for read and write operations with chunks.
+  If any value below zero is set, only one thread will be used.
+
+### worker-threads
+
+- **default**: `-1`
+- **description**: Sets the number of threads to be used for parallel chunk generation. If any value below
+  zero is set, the server will determine the best number depending on the number of available CPU cores
+  _(important: **not** threads i.e. Hyper-Threading doesn't count)_ the runtime.
+
 ## collisions
 
 ### enable-player-collisions

--- a/docs/paper/admin/reference/global-configuration.md
+++ b/docs/paper/admin/reference/global-configuration.md
@@ -12,17 +12,6 @@ Global configuration options exposed by Paper will affect all worlds on a server
 function itself. For per-world configuration, see the
 [Per World Configuration Reference](world-configuration.md)
 
-## async-chunks
-
-### threads
-
-- **default**: `-1`
-- **description**: The number of threads the server should use for world saving and chunk loading.
-  The default (`-1`) indicates that Paper will utilize half of your system's threads for chunk
-  loading unless otherwise specified. There is also a maximum default of 4 threads used for saving
-  and loading chunks. This can be overridden by adding `-Dpaper.maxChunkThreads=[number]` to your
-  startup arguments
-
 ## chunk-loading
 
 ### autoconfig-send-distance


### PR DESCRIPTION
Added description for the new `chunk-system` configuration section and removed the outdated `async-chunks` section following the https://github.com/PaperMC/docs/issues/112 issue.

If there's anyone with better English skills, it'd be much appreciated if you could fix any grammar or just weird sentences stuff in there :)

Also I think it's worth explaining on how exactly the nubmer of default worker threads is determined in the runtime, it's just I couldn't find a way to put it nicely in a sentence.
Relevant code and docs section:
```java
int defaultWorkerThreads = Runtime.getRuntime().availableProcessors() / 2;
if (defaultWorkerThreads <= 4) {
    defaultWorkerThreads = defaultWorkerThreads <= 3 ? 1 : 2;
} else {
    defaultWorkerThreads = defaultWorkerThreads / 2;
}
``` 

```markdown
- **description**: Sets the number of threads to be used for parallel chunk generation. If any value below
  zero is set, the server will determine the best number depending on the number of available CPU cores
  _(important: **not** threads i.e. Hyper-Threading doesn't count)_ the runtime.
```

Fixes https://github.com/PaperMC/docs/issues/112