### PR TITLE
Add permission documentation for /velocity version

### DIFF
--- a/docs/velocity/admin/reference/commands.md
+++ b/docs/velocity/admin/reference/commands.md
@@ -20,7 +20,7 @@ active on the proxy using `/velocity plugins`, including the name, authors, and 
 
 ### `/velocity version`
 
-Displays the version of Velocity running on the proxy.
+If the user has the `velocity.command.info` permission (by default, this is granted to all users), they can view the version of Velocity running on the proxy.
 
 ### `/velocity reload`
 


### PR DESCRIPTION
I was trying to figure out how to disable `/velocity version` for some players and had to [delve into the source code](https://github.com/PaperMC/Velocity/blob/dev/3.0.0/proxy/src/main/java/com/velocitypowered/proxy/command/builtin/VelocityCommand.java#L258) to find the permission node. 

This change adds a note that the permission node `velocity.command.info` controls access to the `/velocity version` command.