### PR TITLE
Document added block update configuration

### DIFF
--- a/docs/paper/admin/reference/configuration/global-configuration.md
+++ b/docs/paper/admin/reference/configuration/global-configuration.md
@@ -12,6 +12,20 @@ Global configuration options exposed by Paper will affect all worlds on a server
 function itself. For per-world configuration, see the
 [Per World Configuration Reference](world-configuration.md)
 
+## block-updates
+
+### disable-noteblock-updates
+- **default**: `false`
+- **description**: Whether to disable any form of block updates for note blocks on the server. Disabling block updates
+  leads to note blocks no longer updating their block state, allowing for technically invalid note blocks to remain in
+  the world, which might be useful for mapmakers.
+
+### disable-tripwire-updates
+- **default**: `false`
+- **description**: Whether to disable any form of block updates for tripwires on the server. Disabling block updates
+  leads to tripwires no longer updating their block state, allowing for technically invalid tripwires to remain in
+  the world, which might be useful for mapmakers.
+
 ## chunk-loading
 
 ### autoconfig-send-distance


### PR DESCRIPTION
The recently merged pull request PaperMC/Paper#9368 allows server owners to disable block updates from affecting note blocks or tripwires, providing an easy way to developers/mapmakers to use them for custom blocks.

This commit provides plain documentation for these two options on the paper documentation page.