### PR TITLE
add expected filepaths to config docs

### DIFF
--- a/docs/paper/admin/reference/configuration/global-configuration.mdx
+++ b/docs/paper/admin/reference/configuration/global-configuration.mdx
@@ -9,7 +9,7 @@ import Config from '@site/src/components/Config';
 
 :::info
 
-The below YAML shows you the structure and default values for the global configuration.
+The below YAML shows you the structure and default values for the global configuration (`config/paper-global.yml`).
 
 Click on a leaf node to view the description for that setting.
 

--- a/docs/paper/admin/reference/configuration/server-properties.mdx
+++ b/docs/paper/admin/reference/configuration/server-properties.mdx
@@ -7,9 +7,9 @@ slug: /reference/server-properties
 import React from 'react';
 import Config from '@site/src/components/Config';
 
-### This page documents the properties that can be set in the `server.properties` file.
-
 :::info
+
+The below page shows the settings and default values for the `server.properties` file.
 
 Click on a property to learn more about it.
 

--- a/docs/paper/admin/reference/configuration/world-configuration.mdx
+++ b/docs/paper/admin/reference/configuration/world-configuration.mdx
@@ -9,7 +9,7 @@ import Config from '@site/src/components/Config';
 
 :::info
 
-The below YAML shows you the structure and default values for the world configuration.
+The below YAML shows you the structure and default values for the world configuration. (`config/paper-world-defaults.yml` and `<worldfolder>/paper-world.yml`)
 
 Click on a leaf node to view the description for that setting.
 
@@ -294,7 +294,7 @@ entities:
   sniffer:
     boosted-hatch-time:
       default: 'default'
-      description: 'The boosted hatch time, in ticks, a sniffer egg requires to hatch. 
+      description: 'The boosted hatch time, in ticks, a sniffer egg requires to hatch.
       Boosted hatching occurs when planted on specific blocks.'
     hatch-time:
       default: 'default'


### PR DESCRIPTION
add the filepath to the paper-config files,
merges file info into the "info" block of server.properties to match paper-global and paper-world

side note: i dont know why idea keeps removing the space, i cannot commit without it disappearing