### PR TITLE
add button that expands/collapses all config descriptions

### DIFF
--- a/src/components/Config.tsx
+++ b/src/components/Config.tsx
@@ -206,7 +206,7 @@ export default function Config({ data, separator = ': ', showDescriptions = fals
     let ymlData = yaml.load(data);
     return (
         <div>
-            <pre className='codeblock'>
+            <pre className='config-button-parent'>
                 <button onClick={() => setShowAllExpanded(!showAllDescriptions)} className={`config-button button button--secondary`}>{showAllDescriptions ? "Collapse All" : "Expand All"}</button>
                 {renderYamlData(ymlData, '', true, separator, showAllDescriptions)}
             </pre>

--- a/src/components/Config.tsx
+++ b/src/components/Config.tsx
@@ -206,7 +206,7 @@ export default function Config({ data, separator = ': ', showDescriptions = fals
     let ymlData = yaml.load(data);
     return (
         <div>
-            <pre className='config-button-parent'>
+            <pre className='relative-container'>
                 <button onClick={() => setShowAllExpanded(!showAllDescriptions)} className={`config-button button button--secondary`}>{showAllDescriptions ? "Collapse All" : "Expand All"}</button>
                 {renderYamlData(ymlData, '', true, separator, showAllDescriptions)}
             </pre>

--- a/src/components/Config.tsx
+++ b/src/components/Config.tsx
@@ -130,17 +130,11 @@ const YamlNodeWithDescription = ({ name, node, parentKey, root, separator, showA
                 >
                     {parseItalics(name)}{parseDefault(node.default.toString(), !showDescription, parentKey, name, handleHashLinkClick, separator)}
                 </a>
-                {showDescription ? (
-                    <>
-                        <div className="indent-2" style={{ marginBottom: 10 }}>
-                            <div className="outlined-box description-text color-offset-box">
-                                <ReactMarkdown className={style.reactMarkDown}>{node.description.toString()}</ReactMarkdown>
-                            </div>
-                        </div>
-                    </>
-                ) : (
-                    <></>
-                )}
+                <div className="indent-2" style={{ marginBottom: 10, display: !showDescription ? "none" : "" }}>
+                    <div className="outlined-box description-text color-offset-box">
+                        <ReactMarkdown className={style.reactMarkDown}>{node.description.toString()}</ReactMarkdown>
+                    </div>
+                </div>
             </div>
         </div>
     );
@@ -210,7 +204,6 @@ export default function Config({ data, separator = ': ', showDescriptions = fals
                 <button onClick={() => setShowAllExpanded(!showAllDescriptions)} className={`config-button button button--secondary`}>{showAllDescriptions ? "Collapse All" : "Expand All"}</button>
                 {renderYamlData(ymlData, '', true, separator, showAllDescriptions)}
             </pre>
-            <div style={{ display: 'none' }}>{data}</div>
         </div>
     );
 }

--- a/src/components/Config.tsx
+++ b/src/components/Config.tsx
@@ -200,7 +200,7 @@ export default function Config({ data, separator = ': ', showDescriptions = fals
     let ymlData = yaml.load(data);
     return (
         <div>
-            <pre className='relative-container'>
+            <pre className='config-container'>
                 <button onClick={() => setShowAllExpanded(!showAllDescriptions)} className={`config-button button button--secondary`}>{showAllDescriptions ? "Collapse All" : "Expand All"}</button>
                 {renderYamlData(ymlData, '', true, separator, showAllDescriptions)}
             </pre>

--- a/src/components/Config.tsx
+++ b/src/components/Config.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import ReactMarkdown from 'react-markdown';
 import style from '@site/src/css/markdown-styles.module.css';
 import yaml from 'js-yaml';
@@ -80,8 +80,9 @@ const parseItalics = (key) => {
     return key;
 }
 
-const YamlNodeWithDescription = ({ name, node, parentKey, root, separator }) => {
-    const [showDescription, setShowDescription] = useState(false);
+const YamlNodeWithDescription = ({ name, node, parentKey, root, separator, showAllDescriptions }) => {
+    const ignoreInitialRenderRef = useRef(false);
+    const [showDescription, setShowDescription] = useState(showAllDescriptions);
 
     node.default = node.default || 'N/A';
     node.description = node.description || 'N/A';
@@ -93,9 +94,17 @@ const YamlNodeWithDescription = ({ name, node, parentKey, root, separator }) => 
         }
     }, [name]);
 
+    useEffect(() => {
+        if (ignoreInitialRenderRef.current) {
+            setShowDescription(!showDescription);
+        } else {
+            ignoreInitialRenderRef.current = true;
+        }
+    }, [showAllDescriptions]);
+
     const handleHashLinkClick = (event) => {
         event.preventDefault();
-        history.pushState(null, null, event.currentTarget.hash);
+        history.pushState(null, "", event.currentTarget.hash);
 
         const fullURL = window.location.href.split('#')[0];
         const hash = createUrlHash(parentKey, name);
@@ -137,14 +146,14 @@ const YamlNodeWithDescription = ({ name, node, parentKey, root, separator }) => 
     );
 };
 
-const YamlTreeNode = ({ root, key, parentKey, value, separator }) => {
+const YamlTreeNode = ({ root, name, parentKey, value, separator, showAllDescriptions }) => {
     const handleClick = (event) => {
         event.preventDefault();
-        scrollIntoView(createUrlHash(parentKey, key));
-        history.pushState(null, null, `#${createUrlHash(parentKey, key)}`);
+        scrollIntoView(createUrlHash(parentKey, name));
+        history.pushState(null, "", `#${createUrlHash(parentKey, name)}`);
 
         const fullURL = window.location.href.split('#')[0];
-        const hash = createUrlHash(parentKey, key);
+        const hash = createUrlHash(parentKey, name);
         navigator.clipboard.writeText(fullURL + '#' + hash);
         scrollIntoView(hash);
 
@@ -159,32 +168,32 @@ const YamlTreeNode = ({ root, key, parentKey, value, separator }) => {
     }
 
     useEffect(() => {
-        const hash = createUrlHash(parentKey, key);
+        const hash = createUrlHash(parentKey, name);
         if (window.location.hash === `#${hash}`) {
             scrollIntoView(hash);
         }
-    }, [key]);
+    }, [name]);
 
     return (
-        <div key={key} className={`highlight-config-node`} style={{ paddingLeft: `${root ? 0 : INDENT_SIZE}px` }} id={createUrlHash(parentKey, key)}>
+        <div key={name} className={`highlight-config-node`} style={{ paddingLeft: `${root ? 0 : INDENT_SIZE}px` }} id={createUrlHash(parentKey, name)}>
             <div className={`config-auxiliary-node`} style={{display: "inline-flex"}}>
-                {parseItalics(key)}{removeTrailingSpaces(separator)}
+                {parseItalics(name)}{removeTrailingSpaces(separator)}
             </div>
-            <a className={`config-anchor with-value-active-color hash-link`} href={`#${createUrlHash(parentKey, key)}`} onClick={handleClick}></a>
-            {renderYamlData(value, parentKey ? createUrlHash(parentKey, key) : parseUrlHash(key), false, separator)}
+            <a className={`config-anchor with-value-active-color hash-link`} href={`#${createUrlHash(parentKey, name)}`} onClick={handleClick}></a>
+            {renderYamlData(value, parentKey ? createUrlHash(parentKey, name) : parseUrlHash(name), false, separator, showAllDescriptions)}
         </div>
     );
 };
 
-const renderYamlData = (data, parentKey, root = false, separator) => {
-    const renderedNodes = [];
+const renderYamlData = (data, parentKey, root = false, separator, showAllDescriptions) => {
+    const renderedNodes: JSX.Element[] = [];
 
     for (const [key, value] of Object.entries(data)) {
-        if (typeof value === 'object') {
+        if (typeof value === 'object' && value !== null) {
             if ('default' in value || 'description' in value) {
-                renderedNodes.push(<YamlNodeWithDescription key={key} name={key} parentKey={parentKey} node={value} root={root} separator={separator} />);
+                renderedNodes.push(<YamlNodeWithDescription key={key} name={key} parentKey={parentKey} node={value} root={root} separator={separator} showAllDescriptions={showAllDescriptions} />);
             } else {
-                renderedNodes.push(YamlTreeNode({ root, key, parentKey, value, separator }));
+                renderedNodes.push(<YamlTreeNode root={root} key={key} name={key} parentKey={parentKey} value={value} separator={separator} showAllDescriptions={showAllDescriptions} />);
             }
         }
     }
@@ -192,11 +201,15 @@ const renderYamlData = (data, parentKey, root = false, separator) => {
     return renderedNodes;
 };
 
-export default function Config({ data, separator = ': ' }) {
+export default function Config({ data, separator = ': ', showDescriptions = false}) {
+    const [showAllDescriptions, setShowAllExpanded] = useState(showDescriptions);
     let ymlData = yaml.load(data);
     return (
         <div>
-            <pre>{renderYamlData(ymlData, '', true, separator)}</pre>
+            <pre className='codeblock'>
+                <button onClick={() => setShowAllExpanded(!showAllDescriptions)} className={`config-button button button--secondary`}>{showAllDescriptions ? "Collapse All" : "Expand All"}</button>
+                {renderYamlData(ymlData, '', true, separator, showAllDescriptions)}
+            </pre>
             <div style={{ display: 'none' }}>{data}</div>
         </div>
     );

--- a/src/components/Config.tsx
+++ b/src/components/Config.tsx
@@ -96,7 +96,7 @@ const YamlNodeWithDescription = ({ name, node, parentKey, root, separator, showA
 
     useEffect(() => {
         if (ignoreInitialRenderRef.current) {
-            setShowDescription(!showDescription);
+            setShowDescription(showAllDescriptions);
         } else {
             ignoreInitialRenderRef.current = true;
         }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -193,7 +193,7 @@ html[data-theme="dark"] {
   width: fit-content;
 }
 
-.config-button-parent {
+.relative-container {
   position: relative;
 }
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -181,6 +181,16 @@ html[data-theme="dark"] {
   width: fit-content;
 }
 
+.codeblock {
+  position: relative;
+}
+
+.config-button {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+}
+
 .config-anchor {
   text-decoration: none;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -193,7 +193,7 @@ html[data-theme="dark"] {
   width: fit-content;
 }
 
-.relative-container {
+.config-container {
   position: relative;
 }
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -194,6 +194,7 @@ html[data-theme="dark"] {
 }
 
 .config-container {
+  font-variant-ligatures: no-contextual;
   position: relative;
 }
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -199,7 +199,8 @@ html[data-theme="dark"] {
 
 .config-button {
   position: absolute;
-  width: 130px;
+  padding: 0px;
+  width: 90px;
   top: 10px;
   right: 10px;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -19,7 +19,7 @@ html[data-theme="dark"] {
   --ifm-color-primary: #409efe;
   --ifm-color-primary-dark: #0175ec;
   --ifm-color-secondary: #ebedf0;
-  --ifm-color-secondary-dark: #ededed;
+  --ifm-color-secondary-dark: #b9b4b4;
 
   --ifm-menu-color: #dadada !important;
   --ifm-toc-link-color: #dadada !important;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1,6 +1,8 @@
 :root {
   --ifm-color-primary: #0240dc;
   --ifm-color-primary-dark: #033ed5;
+  --ifm-color-secondary: #868686;
+  --ifm-color-secondary-dark: #5f5f5f;
   --ifm-color-warning-contrast-background: #ffe39c;
 
   --ifm-code-font-size: 95%;
@@ -16,6 +18,8 @@
 html[data-theme="dark"] {
   --ifm-color-primary: #409efe;
   --ifm-color-primary-dark: #0175ec;
+  --ifm-color-secondary: #ebedf0;
+  --ifm-color-secondary-dark: #ededed;
 
   --ifm-menu-color: #dadada !important;
   --ifm-toc-link-color: #dadada !important;
@@ -25,6 +29,14 @@ html[data-theme="dark"] {
   /* Config Node */
   --default-config-node-text-color: rgb(128, 128, 128);
   --config-node-highlight-text-color: white;
+}
+
+.button.button--secondary {
+  color: #f6f7f8;
+}
+
+[data-theme="dark"] .button.button--secondary {
+  color: #1c1e21;
 }
 
 .header-icon-link::before {
@@ -187,6 +199,7 @@ html[data-theme="dark"] {
 
 .config-button {
   position: absolute;
+  width: 130px;
   top: 10px;
   right: 10px;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -193,7 +193,7 @@ html[data-theme="dark"] {
   width: fit-content;
 }
 
-.codeblock {
+.config-button-parent {
   position: relative;
 }
 


### PR DESCRIPTION
This PR adds a button that lets you expand or collapse all the config descriptions at once. I've also taken the liberty of fixing some of the linter warnings I was getting, as well as some weird issues that I ran into while attempting to implement this feature.

I've also attached a `showDescriptions` parameter to the Config component that defaults to `false`. Setting it to `true` will expand all the descriptions initially. It might be useful to show all descriptions for smaller configs by default, since they don't take up as much screen space.