### PR TITLE
Make config nodes accessible through keyboard shortcuts

### DIFF
--- a/src/components/Config.tsx
+++ b/src/components/Config.tsx
@@ -122,14 +122,14 @@ const YamlNodeWithDescription = ({ name, node, parentKey, root, separator, showA
     return (
         <div style={{ paddingLeft: `${root ? 0 : INDENT_SIZE}px` }} id={createUrlHash(parentKey, name)}>
             <div className={`description_word_wrap`} style={{ marginBottom: showDescription ? 10 : 0 }}>
-                <a
+                <button
                     onClick={() => {
                         setShowDescription(!showDescription);
                     }}
-                    className={`with-value${showDescription ? '-active' : ''}`}
+                    className={`config-node with-value${showDescription ? '-active' : ''} clean-btn button--link`}
                 >
                     {parseItalics(name)}{parseDefault(node.default.toString(), !showDescription, parentKey, name, handleHashLinkClick, separator)}
-                </a>
+                </button>
                 <div className="indent-2" style={{ marginBottom: 10, display: !showDescription ? "none" : "" }}>
                     <div className="outlined-box description-text color-offset-box">
                         <ReactMarkdown className={style.reactMarkDown}>{node.description.toString()}</ReactMarkdown>

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -149,6 +149,12 @@ html[data-theme="dark"] {
   padding-left: calc(var(--ifm-menu-link-padding-horizontal) - var(--size));
 }
 
+.config-node {
+  font: var(--ifm-font-size-base)/var(--ifm-pre-line-height) var(--ifm-font-family-monospace);
+  text-decoration: none !important; /* SHOULD work without !important, but doesn't... */
+  text-align: left;
+}
+
 .with-value {
   transition: color 0.3s;
   cursor: pointer;


### PR DESCRIPTION
This PR replaces the anchor element used for the config nodes with the button element. `clean-btn` and `button--link` are applied to render the button the same as an anchor element, and `config-node` is used for any leftover stylings required to keep visual parity.

https://github.com/PaperMC/docs/assets/43185817/62efe4ca-4f5b-4e59-a836-8655f46ad953

(keystroke visualizer: https://github.com/mulaRahul/keyviz)

Near the end of the video I notice a weird inconsistency with the config descriptions for the `hidden-blocks` and `replacement-blocks` showing incorrectly in production compared to my dev environment. Not sure what's up with that.