### PR TITLE
Remove reference to a guide that doesn't exist

### DIFF
--- a/docs/paper/admin/reference/configuration/global-configuration.mdx
+++ b/docs/paper/admin/reference/configuration/global-configuration.mdx
@@ -239,8 +239,7 @@ packet-limiter:
     description: 'Override the global configuration for any individual named packet.
       You can find the names of every packet as they are displayed on timings. For
       more experienced users, packets named here use Mojang mappings regardless of
-      the server. For more information about overrides, see the [Packet Limiter
-      Guide]..'
+      the server.'
 player-auto-save:
   max-per-tick:
     default: '-1'


### PR DESCRIPTION
This bit used to be commented out, but after the big config revamp the comment part was removed