### PR TITLE
Mention disabling server.props online mode in forwarding guide

### DIFF
--- a/docs/velocity/admin/getting-started/forwarding.md
+++ b/docs/velocity/admin/getting-started/forwarding.md
@@ -46,7 +46,10 @@ to use Velocity forwarding.
 Paper 1.14+ and above, along with Paper 1.13.1/1.13.2 build 377 and above support Velocity modern
 forwarding natively.
 
-First, you need to disable BungeeCord forwarding if you had it enabled beforehand. Make sure
+First, you need to disable the `online-mode` setting in the `server.properties` file. This prevents
+the server from authenticating players, which the proxy will do instead.
+
+You also need to disable BungeeCord forwarding if you had it enabled beforehand. Make sure
 `settings.bungeecord` is set to `false` in your `spigot.yml`.
 
 In `config/paper-global.yml`, set `proxies.velocity.enabled` to true and

--- a/docs/velocity/admin/getting-started/forwarding.md
+++ b/docs/velocity/admin/getting-started/forwarding.md
@@ -46,7 +46,7 @@ to use Velocity forwarding.
 Paper 1.14+ and above, along with Paper 1.13.1/1.13.2 build 377 and above support Velocity modern
 forwarding natively.
 
-First, you need to disable the `online-mode` setting in the [`server.properties`](../../../paper/reference/server-properties) file. This prevents
+First, you need to disable the `online-mode` setting in the [`server.properties`](/paper/reference/server-properties#online_mode) file. This prevents
 the server from authenticating players, which the proxy will do instead.
 
 You also need to disable BungeeCord forwarding if you had it enabled beforehand. Make sure

--- a/docs/velocity/admin/getting-started/forwarding.md
+++ b/docs/velocity/admin/getting-started/forwarding.md
@@ -46,7 +46,7 @@ to use Velocity forwarding.
 Paper 1.14+ and above, along with Paper 1.13.1/1.13.2 build 377 and above support Velocity modern
 forwarding natively.
 
-First, you need to disable the `online-mode` setting in the `server.properties` file. This prevents
+First, you need to disable the `online-mode` setting in the [`server.properties`](../../../paper/reference/server-properties) file. This prevents
 the server from authenticating players, which the proxy will do instead.
 
 You also need to disable BungeeCord forwarding if you had it enabled beforehand. Make sure


### PR DESCRIPTION
Not *too* sure on the wording, so suggestions welcomed. Disabling online mode in the server.properties is mentioned in the getting started guide at the very bottom, but worth mentioning on this page aswell

do we also want to mention this in the legacy forwarding part?