### PR TITLE
fix typo

### DIFF
--- a/docs/paper/dev/getting-started/userdev.md
+++ b/docs/paper/dev/getting-started/userdev.md
@@ -45,6 +45,7 @@ want to use SNAPSHOT versions, you must add Paper's maven repo to `settings.grad
 ```kotlin
 pluginManagement {
     repositories {
+        gradlePluginPortal()
         maven("https://repo.papermc.io/repository/maven-public/")
     }
 }

--- a/docs/paper/dev/getting-started/userdev.md
+++ b/docs/paper/dev/getting-started/userdev.md
@@ -44,7 +44,7 @@ plugins {
 want to use SNAPSHOT versions, you must add Paper's maven repo to `settings.gradle.kts` with:
 ```kotlin
 pluginManagement {
-    repositores {
+    repositories {
         maven("https://repo.papermc.io/repository/maven-public/")
     }
 }


### PR DESCRIPTION
also adds the gradle plugin portal since it'll break if you have any plugins (such as `org.gradle.toolchains.foojay-resolver-convention`) without it