### PR TITLE
add compression-level description

### DIFF
--- a/docs/paper/admin/reference/configuration/global-configuration.mdx
+++ b/docs/paper/admin/reference/configuration/global-configuration.mdx
@@ -218,6 +218,9 @@ misc:
     chat-executor-max-size:
       default: '-1'
       description: 'The maximum number of threads to allow in the chat thread pool. The default value is -1, which means no maximum'
+  compression-level:
+    default: 'default'
+    description: 'A higher compression level means less data transmitted for the cost of more CPU time.'
 packet-limiter:
   all-packets:
     action:

--- a/docs/paper/admin/reference/configuration/global-configuration.mdx
+++ b/docs/paper/admin/reference/configuration/global-configuration.mdx
@@ -220,7 +220,10 @@ misc:
       description: 'The maximum number of threads to allow in the chat thread pool. The default value is -1, which means no maximum'
   compression-level:
     default: 'default'
-    description: 'A higher compression level means less data transmitted for the cost of more CPU time.'
+    description: 'A higher compression level means less data transmitted for the cost of more CPU time.
+      The default value is -1, which means that the server will use the default value of the defined compressor.
+      Note that Paper is currently using the Velocity compressor, which uses a default compression level of 6 as a middle ground
+      between performance and data transmission.'
 packet-limiter:
   all-packets:
     action:

--- a/docs/paper/admin/reference/configuration/global-configuration.mdx
+++ b/docs/paper/admin/reference/configuration/global-configuration.mdx
@@ -220,7 +220,7 @@ misc:
       description: 'The maximum number of threads to allow in the chat thread pool. The default value is -1, which means no maximum'
   compression-level:
     default: 'default'
-    description: 'A higher compression level means less data transmitted for the cost of more CPU time.
+    description: 'A higher compression level means less data transmitted at the cost of more CPU time.
       The default value is -1, which means that the server will use the default value of the defined compressor.
       Note that Paper is currently using the Velocity compressor, which uses a default compression level of 6 as a middle ground
       between performance and data transmission.'


### PR DESCRIPTION
This adds the necessary description for the new `compression-level` config option in `config/paper-global.yml`

See https://github.com/PaperMC/Paper/pull/9711