### PR TITLE
Adds missing word 'load' in paper-plugins guide

### DIFF
--- a/docs/paper/dev/getting-started/paper-plugins.md
+++ b/docs/paper/dev/getting-started/paper-plugins.md
@@ -70,7 +70,7 @@ RegistryPlugin:
   join-classpath: true # Defaults to true
 ```
 
-- `load`: (`BEFORE`|`AFTER`|`OMIT`) Specifies whether this plugin should before or after **your** plugin. Note: Omit has undefined ordering behavior.
+- `load`: (`BEFORE`|`AFTER`|`OMIT`) Specifies whether this plugin should load before or after **your** plugin. Note: Omit has undefined ordering behavior.
 - `required`: Whether this plugin is required for your plugin to load.
 - `join-classpath`: Whether your plugin should have access to their classpath. This is used for plugins that need to access other plugins internals directly.
 


### PR DESCRIPTION
Noticed that this line
![image](https://github.com/PaperMC/docs/assets/29175884/a66d6473-724b-4c00-9fbc-17a88e4e49d6)
was missing the word `load` between `this plugin should` and `before or after`.

Corrected Version:
![image](https://github.com/PaperMC/docs/assets/29175884/3747dce5-8dfc-40d2-9e33-4e90eedd49d7)
