### PR TITLE
Minor improvements to internals and userdev pages

### DIFF
--- a/docs/paper/dev/getting-started/userdev.md
+++ b/docs/paper/dev/getting-started/userdev.md
@@ -45,7 +45,7 @@ Only the latest version of `paperweight-userdev` is officially supported, and we
 :::info[Snapshots]
 
 **paperweight-userdev** releases are available through the [Gradle Plugin Portal](https://plugins.gradle.org/plugin/io.papermc.paperweight.userdev), but if you
-want to use SNAPSHOT versions, you must add Paper's maven repo to `settings.gradle.kts` with:
+want to use SNAPSHOT versions, you must add Paper's Maven repository to `settings.gradle.kts` with:
 ```kotlin
 pluginManagement {
     repositories {

--- a/docs/paper/dev/getting-started/userdev.md
+++ b/docs/paper/dev/getting-started/userdev.md
@@ -1,7 +1,7 @@
 ---
 slug: /dev/userdev
 sidebar_label: Paperweight Userdev
-description: A guide on how to use the Paperweight Userdev Gradle plugin to access internal code.
+description: A guide on how to use the paperweight-userdev Gradle plugin to access internal code.
 ---
 
 # paperweight-userdev
@@ -11,7 +11,7 @@ provides access to internal code (also known as NMS) during development.
 
 :::note
 
-This guide is written using the Kotlin DSL for Gradle and assumes you have some basic knowledge of Gradle.
+This guide is written using the Gradle Kotlin DSL and assumes you have some basic knowledge of Gradle.
 If you want to see a fully-functioning plugin that uses **paperweight-userdev**,
 check out this [example plugin](https://github.com/PaperMC/paperweight-test-plugin).
 
@@ -21,7 +21,7 @@ check out this [example plugin](https://github.com/PaperMC/paperweight-test-plug
 The Paper server jars we provide on the downloads page through the API are **paperclip** jars. These
 use Spigot's mappings, which are essentially some type names, but fully obfuscated fields and methods.
 This can make it hard to work with in a development environment. This plugin lets you use fully deobfuscated
-types, names and fields during development, and then remaps your plugin, so it can still be used with the obfuscated
+types, names, and fields during development, and then remaps your plugin, so it can still be used with the obfuscated
 server.
 
 :::caution
@@ -35,13 +35,13 @@ use non-obfuscated names in reflection.
 Add the plugin to your `build.gradle.kts` file.
 ```kotlin
 plugins {
-    id("io.papermc.paperweight.userdev") version "1.5.5" // the latest version can be found on the Gradle Plugin Portal
+    id("io.papermc.paperweight.userdev") version "1.5.10" // Check for new versions at https://plugins.gradle.org/plugin/io.papermc.paperweight.userdev
 }
 ```
 
 :::info[Snapshots]
 
-**paperweight-userdev** releases are available through the Gradle plugin portal, but if you
+**paperweight-userdev** releases are available through the [Gradle Plugin Portal](https://plugins.gradle.org/plugin/io.papermc.paperweight.userdev), but if you
 want to use SNAPSHOT versions, you must add Paper's maven repo to `settings.gradle.kts` with:
 ```kotlin
 pluginManagement {
@@ -54,7 +54,7 @@ pluginManagement {
 
 :::
 
-## Adding the dev-bundle dependency
+## Adding the dev bundle dependency
 If you try to load your Gradle project now, you will receive an error saying you have to declare
 a dev bundle dependency. You can do that by adding to your `dependencies` block in your `build.gradle.kts`
 file.
@@ -67,7 +67,7 @@ dependencies {
 ```
 :::tip
 
-You can remove any dependency for the Paper API, as the dev bundle includes that.
+You should remove any dependency on the Paper API, as the dev bundle includes that.
 
 :::
 

--- a/docs/paper/dev/getting-started/userdev.md
+++ b/docs/paper/dev/getting-started/userdev.md
@@ -52,6 +52,9 @@ pluginManagement {
 }
 ```
 
+The latest version of `paperweight-userdev` supports dev bundles for Minecraft 1.17.1 and newer, so it's best practice to keep it up to date!
+Only the latest version of `paperweight-userdev` is officially supported, and we will ask you to update first if you are having problems with old versions.
+
 :::
 
 ## Adding the dev bundle dependency

--- a/docs/paper/dev/getting-started/userdev.md
+++ b/docs/paper/dev/getting-started/userdev.md
@@ -39,6 +39,9 @@ plugins {
 }
 ```
 
+The latest version of `paperweight-userdev` supports dev bundles for Minecraft 1.17.1 and newer, so it's best practice to keep it up to date!
+Only the latest version of `paperweight-userdev` is officially supported, and we will ask you to update first if you are having problems with old versions.
+
 :::info[Snapshots]
 
 **paperweight-userdev** releases are available through the [Gradle Plugin Portal](https://plugins.gradle.org/plugin/io.papermc.paperweight.userdev), but if you
@@ -51,9 +54,6 @@ pluginManagement {
     }
 }
 ```
-
-The latest version of `paperweight-userdev` supports dev bundles for Minecraft 1.17.1 and newer, so it's best practice to keep it up to date!
-Only the latest version of `paperweight-userdev` is officially supported, and we will ask you to update first if you are having problems with old versions.
 
 :::
 

--- a/docs/paper/dev/misc/internal-code.mdx
+++ b/docs/paper/dev/misc/internal-code.mdx
@@ -27,12 +27,12 @@ any time.
 
 ## Accessing Minecraft Internals
 
-In order to use Mojang and CraftBukkit code, you may either use the Paperweight Userdev plugin or use reflection.
-The [Paperweight Userdev](https://github.com/PaperMC/paperweight-test-plugin) plugin is the recommended way to access internal code
+In order to use Mojang and CraftBukkit code, you may either use the `paperweight-userdev` Gradle plugin or use reflection.
+[`paperweight-userdev`](https://github.com/PaperMC/paperweight-test-plugin) is the recommended way to access internal code
 as it is easier to use due to being able to have the remapped code in your IDE. You can find
-out more about this in the [Paperweight Userdev](/paper/dev/userdev) section.
+out more about this in the [`paperweight-userdev`](/paper/dev/userdev) section.
 
-However, if you are unable to use the Userdev plugin, you can use reflection.
+However, if you are unable to use `paperweight-userdev`, you can use reflection.
 
 ### Reflection
 
@@ -59,7 +59,7 @@ Class.forName(cbClass("entity.CraftBee"));
 
 Minecraft's code is obfuscated. This means that the names of classes and methods are changed to make them harder to
 understand. Paper deobfuscates these identifiers for development; however, to provide compatibility with legacy plugins,
-Paper is re-obfuscated at runtime. You can use a plugin like [Reflection Remapper](https://github.com/jpenilla/reflection-remapper) to automatically remap the
+Paper is re-obfuscated at runtime. You can use a library like [reflection-remapper](https://github.com/jpenilla/reflection-remapper) to automatically remap the
 reflection references. This will allow you to use the de-obfuscated, Mojang-mapped, names in your code. This is recommended as
 it makes the code easier to understand.
 
@@ -68,7 +68,7 @@ it makes the code easier to understand.
 Running a Mojang-Mapped (moj-map) server is an excellent way to streamline your processes because you can develop using
 the same mappings that will be present at runtime. This eliminates the need for remapping in your compilation. If you
 are creating custom plugins for your server, we highly recommend running a moj-map server. It simplifies debugging and
-allows for you to hotswap plugins.
+allows you to hotswap plugins.
 
 In the future, the Paper server will no longer undergo remapping. By adopting Mojang mappings now, you can ensure that
 your plugin won't require internal remapping when we make the switch.
@@ -76,7 +76,7 @@ your plugin won't require internal remapping when we make the switch.
 ### Getting the current Minecraft version
 
 You can get the current Minecraft version to allow you to use the correct code for a specific version. This can be done
-with the one of the following methods:
+with one of the following methods:
 
 ```java
 // Example value: 1.20.2


### PR DESCRIPTION
Bumped the pw version, fixed a couple typos/grammar issues, and made mentions of `paperweight-userdev` *more* consistently stylized, notable exception is I left the sidebar Title Case since it felt weird with the usual kebab case used by pw. Also added a note about keeping userdev up to date.