### PR TITLE
Improved Velocity command documentation with newly added API

### DIFF
--- a/docs/velocity/dev/api/command.md
+++ b/docs/velocity/dev/api/command.md
@@ -25,8 +25,6 @@ package com.example.velocityplugin;
 
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.Command;
-import com.mojang.brigadier.builder.LiteralArgumentBuilder;
-import com.mojang.brigadier.builder.RequiredArgumentBuilder;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import com.velocitypowered.api.command.BrigadierCommand;
 import com.velocitypowered.api.command.CommandSource;
@@ -38,8 +36,7 @@ import net.kyori.adventure.text.format.NamedTextColor;
 public final class TestBrigadierCommand {
 
     public static BrigadierCommand createBrigadierCommand(final ProxyServer proxy) {
-        LiteralCommandNode<CommandSource> helloNode = LiteralArgumentBuilder
-            .<CommandSource>literal("test")
+        LiteralCommandNode<CommandSource> helloNode = BrigadierCommand.literalArgumentBuilder("test")
             // Here you can filter the subjects that can execute the command.
             // This is the ideal place to do "hasPermission" checks
             .requires(source -> source.hasPermission("test.permission"))
@@ -56,13 +53,13 @@ public final class TestBrigadierCommand {
                 // Returning BrigadierCommand.FORWARD will send the command to the server
                 return Command.SINGLE_SUCCESS;
             })
-            // Using the "then" method, you can add subarguments to the command.
+            // Using the "then" method, you can add sub-arguments to the command.
             // For example, this subcommand will be executed when using the command "/test <some argument>"
             // A RequiredArgumentBuilder is a type of argument in which you can enter some undefined data
             // of some kind. For example, this example uses a StringArgumentType.word() that requires
             // a single word to be entered, but you can also use different ArgumentTypes provided by Brigadier
             // that return data of type Boolean, Integer, Float, other String types, etc
-            .then(RequiredArgumentBuilder.<CommandSource, String>argument("argument", StringArgumentType.word())
+            .then(BrigadierCommand.requiredArgumentBuilder("argument", StringArgumentType.word())
                 // Here you can define the hints to be provided in case the ArgumentType does not provide them.
                 // In this example, the names of all connected players are provided
                 .suggests((ctx, builder) -> {
@@ -72,11 +69,16 @@ public final class TestBrigadierCommand {
                             player.getUsername(),
                             // A VelocityBrigadierMessage takes a component.
                             // In this case, the player's name is provided with a rainbow
-                            // gradient created by MiniMessage (Library available since Velocity 3.1.2+)
+                            // gradient created using MiniMessage.
                             VelocityBrigadierMessage.tooltip(
                                     MiniMessage.miniMessage().deserialize("<rainbow>" + player.getUsername())
                             )
                     ));
+                    // If you do not need to add a tooltip to the hint
+                    // or your command is intended only for versions lower than Minecraft 1.13,
+                    // you can omit adding the tooltip, since for older clients,
+                    // the tooltip will not be displayed.
+                    builder.suggest("all");
                     return builder.buildFuture();
                 })
                 // Here the logic of the command "/test <some argument>" is executed
@@ -135,7 +137,7 @@ public final class TestCommand implements SimpleCommand {
         // Get the arguments after the command alias
         String[] args = invocation.arguments();
 
-        source.sendMessage(Component.text("Hello World!").color(NamedTextColor.AQUA));
+        source.sendMessage(Component.text("Hello World!", NamedTextColor.AQUA));
     }
 
     // This method allows you to control who can execute the command.


### PR DESCRIPTION
A week ago [new methods were implemented in the Velocity API module](https://github.com/PaperMC/Velocity/pull/1161) that can help to understand more easily the operation of the Brigadier commands especially for those who are just starting with the Velocity API, by avoiding using generics and adding useful checks to avoid beginner mistakes.
![image](https://github.com/PaperMC/docs/assets/68704415/f0e5f16b-5b21-4433-99ba-c5f94ecd713d)

I didn't make this pull request earlier because I was waiting for the javadocs to be updated with these changes, which just happened a [few minutes ago](https://discord.com/channels/289587909051416579/908507886420910101/1192999650697937049)
