### PR TITLE
style(typos): spell check variants of `cancellable`

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,5 +1,8 @@
 [files]
-extend-exclude = ["docs/versioned"] # don't check ./docs/versioned
+extend-exclude = [
+    "docs/versioned", # old documentation shouldn't be checked
+    "*.json"          # mostly configuration, not worth checking
+]
 
 [default]
 locale = "en-us"


### PR DESCRIPTION
Not sure whether breaking away from strictly US English is desirable, but I think it makes sense to use the British spelling here to stay consistent with the Bukkit (Paper) API.