### PR TITLE
Move the ip logging configuration reference

### DIFF
--- a/config-specs/paper/paper-global.yml
+++ b/config-specs/paper/paper-global.yml
@@ -154,11 +154,6 @@ logging:
     description: >-
       Whether to remap Spigot mapped stacktraces to Mojang mappings in logging.
       Has no impact on Mojang mapped servers
-  log-player-ip-addresses:
-    default: "true"
-    description: >-
-      Whether player IP addresses should be logged by the server. This does not
-      impact the ability of plugins to log the IP addresses of players
 messages:
   no-permission:
     default: >-

--- a/config-specs/paper/server-properties.yml
+++ b/config-specs/paper/server-properties.yml
@@ -98,6 +98,11 @@ level-type:
   description: >
     Defines the type of the world generator. (Allowed values: "normal", "flat", "large_biomes",
     "amplified", "single_biome_surface", "buffet", "default_1_1", "customized")
+log-ips:
+  default: "true"
+  description: >-
+    Whether player IP addresses should be logged by the server. This does not
+    impact the ability of plugins to log the IP addresses of players
 max-chained-neighbor-updates:
   default: "1000000"
   description: >


### PR DESCRIPTION
The ip logging option was implemented by mojang in 1.20.2 and replaced the existing paper configuration option.
This commit properly moves the documentation and name of that option.