### PR TITLE
Document vanilla breaking changes

### DIFF
--- a/config-specs/paper/vanilla/paper-global.yml
+++ b/config-specs/paper/vanilla/paper-global.yml
@@ -1,0 +1,61 @@
+commands:
+  fix-target-selector-tag-completion:
+    default: "false"
+  suggest-player-names-when-null-tab-completions:
+    default: "false"
+  time-command-affects-all-worlds:
+    default: "true"
+item-validation:
+  book:
+    author:
+      default: "2147483647"
+    title:
+      default: "2147483647"
+    page:
+      default: "2147483647"
+  display-name:
+    default: "2147483647"
+  book-size:
+    page-max:
+      default: "2147483647"
+    total-multiplier:
+      default: "1.0"
+    lore-line:
+      default: "2147483647"
+  resolve-selectors-in-books:
+    default: "true"
+misc:
+  max-joins-per-tick:
+    default: "2147483647"
+  fix-entity-position-desync:
+    default: "false"
+packet-limiter:
+  default: "<expand>"
+  description: >-
+    Vanilla has no packet limit by default (to disable it for all practical purposes set `all-packets.interval` to 0.000001 and `all-packets.max-packet-rate` to 999999.0,
+    but it's better for security to set more specific limits). It's not feasible to reach Paper's default packet limit with a Vanilla client.
+    This defaults to 500 packets per 7 seconds. If you want, you can override this setting for specific packets.
+spam-limiter:
+  default: "<expand>"
+  description: >-
+    You may want to look into this for fast crafting. Vanilla has no spam limit (set the limits to 2147483647 for this), although it's not feasible to reach Paper's default spam limit with a Vanilla client.
+unsupported-settings:
+  inline-docs-warning:
+    title: "Unsupported Settings"
+    message: >-
+      The following settings are provided by Paper, but are not officially
+      supported. They may be removed at any time, so use them at your own risk.
+  allow-headless-pistons:
+    default: "true"
+  allow-permanent-block-break-exploits:
+    default: "true"
+  allow-piston-duplication:
+    default: "true"
+  perform-username-validation:
+    default: "false"
+  allow-grindstone-overstacking:
+    default: "true"
+  allow-unsafe-end-portal-teleportation:
+    default: "true"
+  allow-tripwire-disarming-exploits:
+    default: "true"

--- a/config-specs/paper/vanilla/paper-world-defaults.yml
+++ b/config-specs/paper/vanilla/paper-world-defaults.yml
@@ -1,0 +1,45 @@
+chunks:
+  delay-chunk-unloads-by:
+    default: "0s"
+  max-auto-save-chunks-per-tick:
+    default: "200"
+collisions:
+  allow-player-cramming-damage:
+    default: "true"
+  max-entity-collisions:
+    default: "2147483647"
+    description: >-
+      The actual default value would be infinity. 2147483647 is the closest to infinity.
+entities:
+  behavior:
+    phantoms-do-not-spawn-on-creative-players:
+      default: "false"
+    phantoms-only-attack-insomniacs:
+      default: "false"
+  spawning:
+    count-all-mobs-for-spawning:
+      default: "true"
+    per-player-mob-spawns:
+      default: "false"
+    duplicate-uuid:
+      mode:
+        default: "NOTHING"
+    filter-bad-tile-entity-nbt-from-falling-blocks:
+      default: "false"
+    filtered-entity-tag-nbt-paths:
+      default: "<expand>"
+      description: "The default value is: []"
+fixes:
+  disable-unloaded-chunk-enderpearl-exploit:
+    default: "false"
+hopper:
+  cooldown-when-full:
+    default: "false"
+maps:
+  item-frame-cursor-limit:
+    default: "2147483647"
+unsupported-settings:
+  disable-world-ticking-when-empty:
+    default: "true"
+  fix-invulnerable-end-crystal-exploit:
+    default: "false"

--- a/config-specs/paper/vanilla/spigot.yml
+++ b/config-specs/paper/vanilla/spigot.yml
@@ -1,0 +1,19 @@
+world-settings:
+  default:
+    entity-activation-range:
+      animals:
+        default: "0"
+      monsters:
+        default: "0"
+      raiders:
+        default: "0"
+      misc:
+        default: "0"
+      water:
+        default: "0"
+      villagers:
+        default: "0"
+      flying-monsters:
+        default: "0"
+    max-tnt-per-tick:
+      default: "0"

--- a/config/sidebar.paper.ts
+++ b/config/sidebar.paper.ts
@@ -38,6 +38,7 @@ const paper: SidebarsConfig = {
             "admin/how-to/update",
             "admin/how-to/aikars-flags",
             "admin/how-to/anti-xray",
+            "admin/how-to/get-to-vanilla",
           ],
         },
         {

--- a/docs/paper/admin/how-to/get-to-vanilla.mdx
+++ b/docs/paper/admin/how-to/get-to-vanilla.mdx
@@ -1,0 +1,45 @@
+---
+slug: /vanilla
+description: This page lists all changes that result in a different experience than Vanilla.
+---
+
+# Vanilla-like Experience
+
+import React from 'react';
+import ConfigDocBlock from '@site/src/components/config/ConfigDocBlock';
+import VanillaWorldDefaults from '!!raw-loader!@site/config-specs/paper/vanilla/paper-world-defaults.yml'
+import VanillaGlobalDefaults from '!!raw-loader!@site/config-specs/paper/vanilla/paper-global.yml'
+import SpigotChanges from '!!raw-loader!@site/config-specs/paper/vanilla/spigot.yml'
+
+Due to the way the Bukkit API is implemented in Paper, the gameplay experience between Vanilla and Paper can have inconsistencies.
+This can be furthered by efforts to fix bugs present in Vanilla Minecraft.
+Whilst many people may not notice the inconsistencies, there are situations where they become problematic.
+One example is that technical players may struggle getting their machines to work like they should.
+This page aims to provide a starting point for players who want to get as close to Vanilla as possible.
+
+:::info
+
+This page is inspired by [Earthcomputer's collection](https://gist.github.com/Earthcomputer/2296da33b8cc91dba81b48103c0e1fe3) of Vanilla breaking changes.
+
+:::
+
+:::warning
+
+This guide will only help you to get as close to Vanilla as possible.
+Unfortunately, it currently is not possible to get a 100% Vanilla experience in Paper.
+
+:::
+
+## paper-world-defaults.yml
+<ConfigDocBlock data={VanillaWorldDefaults}/>
+
+## paper-global.yml
+<ConfigDocBlock data={VanillaGlobalDefaults}/>
+
+## spigot.yml
+<ConfigDocBlock data={SpigotChanges}/>
+
+## Further considerations
+
+* `settings.timeout-time` in `spigot.yml` mirrors the watchdog setting in the `server.properties` file. Keep in mind that the `spigot.yml` setting is in seconds while the default setting is in milliseconds.
+* `watchdog` in `paper-global.yml` controls the watchdog early warning. While this is only a warning, you might want to disable it as it can get annoying.


### PR DESCRIPTION
This PR aims to set the foundation for the "How to get as close as possible to a vanilla experience" page. 
I took https://github.com/PaperMC/docs/issues/21#issuecomment-1062254884 as a reference for the initial work. Some of the settings listed don't exist anymore. 

I am sure those are not the only ones. Therefore, I would appreciate it if we can find more settings together as it would be a huge effort for one person to go through every setting. 

Ideally, we would add a little text to why these changes have been made and stuff like that. Please provide feedback in this direction. The design is also not final, but I think that would be the logical design choice? With listing every file that contains vanilla breaking changes as separate config.
I also think we should include a link at each setting, linking to the reference.  See `duplicate-uuid` for an initial design. 