### PR TITLE
Added BungeeForge note to Velocity server-compatibility.mdx

### DIFF
--- a/docs/velocity/admin/reference/server-compatibility.mdx
+++ b/docs/velocity/admin/reference/server-compatibility.mdx
@@ -78,7 +78,8 @@ or [SpongeForge](https://spongepowered.org/downloads/spongeforge) mod correspond
 Minecraft Forge for Minecraft 1.7.2-1.12.2 is fully compatible with Velocity, as we make special
 provisions to synchronize client state with each server. However, we **strongly** recommend the use
 of SpongeForge, as it allows you to use legacy BungeeCord player info forwarding and generally
-improves proxy support in general.
+improves proxy support in general. [BungeeForge](https://github.com/caunt/BungeeForge) can be used
+in situations where SpongeForge is either not supported or compatible with your modpack.
 
 Velocity does not support Forge-Bukkit hybrids - they have caused several issues, and the design of
 the Bukkit API precludes any notion of sane mod support.


### PR DESCRIPTION
Specifically under the Minecraft Forge (1.7.2-1.12.2) section, BungeeForge can be used in situations where SpongeForge isn't supported, compatible, or if the server admin feels their server doesn't need SpongeForge.