### PR TITLE
Fix wrong version reference in API call

### DIFF
--- a/docs/misc/downloads-api.mdx
+++ b/docs/misc/downloads-api.mdx
@@ -45,12 +45,11 @@ This will get the latest stable build for the given project and Minecraft versio
 #!/bin/bash
 
 PROJECT="paper"
-MINECRAFT_VERSION="%%_MAJ_MIN_MC_%%"
 
 LATEST_VERSION=$(curl -s https://api.papermc.io/v2/projects/${PROJECT} | \
     jq -r '.versions[-1]')
 
-LATEST_BUILD=$(curl -s https://api.papermc.io/v2/projects/${PROJECT}/versions/${MINECRAFT_VERSION}/builds | \
+LATEST_BUILD=$(curl -s https://api.papermc.io/v2/projects/${PROJECT}/versions/${LATEST_VERSION}/builds | \
     jq -r '.builds | map(select(.channel == "default") | .build) | .[-1]')
 
 JAR_NAME=${PROJECT}-${LATEST_VERSION}-${LATEST_BUILD}.jar


### PR DESCRIPTION
MINECRAFT_VERSION="1.20.4" is surely a copy/paste oversight, we need to obtain the build of the LATEST_VERSION and not of the MINECRAFT_VERSION, in the next steps we are rightfully referring only to the LATEST_VERSION.