### PR TITLE
Update userdev version to latest

### DIFF
--- a/docs/paper/dev/getting-started/userdev.mdx
+++ b/docs/paper/dev/getting-started/userdev.mdx
@@ -35,7 +35,7 @@ use non-obfuscated names in reflection.
 Add the plugin to your `build.gradle.kts` file.
 ```kotlin
 plugins {
-    id("io.papermc.paperweight.userdev") version "1.5.10" // Check for new versions at https://plugins.gradle.org/plugin/io.papermc.paperweight.userdev
+    id("io.papermc.paperweight.userdev") version "1.5.12" // Check for new versions at https://plugins.gradle.org/plugin/io.papermc.paperweight.userdev
 }
 ```
 


### PR DESCRIPTION
According to https://plugins.gradle.org/plugin/io.papermc.paperweight.userdev, the latest version is now 1.5.12
This PR is supposed to update that