### PR TITLE
Improve Start Script Generation for Windows

### DIFF
--- a/src/components/StartScriptGenerator.tsx
+++ b/src/components/StartScriptGenerator.tsx
@@ -72,7 +72,7 @@ const generateStartCommand = (
 ) => {
   setTimeout(resizeOutput, 0);
   let content = "";
-  const command = `java -Xmx${memory * 1024}M -Xms${memory * 1024}M ${selectedFlag.value}${selectedFlag === FLAGS.NONE ? "" : " "}-jar ${filename === "" ? "server.jar" : filename} ${guiEnabled || selectedFlag === FLAGS.VELOCITY ? "" : "--nogui"}`;
+  const command = `java -Xmx${memory * 1024}M -Xms${memory * 1024}M ${selectedFlag.value}${selectedFlag === FLAGS.NONE ? "" : " "}-jar ${filename === "" ? "server.jar" : filename} ${guiEnabled || selectedFlag === FLAGS.VELOCITY ? "" : "nogui"}`;
 
   if (autoRestartEnabled)
     content = (platform === "windows" ? WINDOWS_AUTO_RESTART : LINUX_AUTO_RESTART).replace(

--- a/src/components/StartScriptGenerator.tsx
+++ b/src/components/StartScriptGenerator.tsx
@@ -81,8 +81,7 @@ const generateStartCommand = (
     );
   else content = platform === "windows" ? command + "\n\npause" : command;
 
-  if (platform === "linux") content = "#!/bin/bash\n\n" + content;
-  if (platform === "windows") content = "@echo off\n\n" + content;
+  content = (platform === "linux" ? "#!/bin/bash\n\n" : "@echo off\n\n") + content;
 
   return content;
 };

--- a/src/components/StartScriptGenerator.tsx
+++ b/src/components/StartScriptGenerator.tsx
@@ -79,9 +79,10 @@ const generateStartCommand = (
       "%%CONTENT%%",
       command
     );
-  else content = command;
+  else content = platform === "windows" ? command + "\n\npause" : command;
 
   if (platform === "linux") content = "#!/bin/bash\n\n" + content;
+  if (platform === "windows") content = "@echo off\n\n" + content;
 
   return content;
 };


### PR DESCRIPTION
adds an @echo off in front of all windows scripts and adds a pause statement after if auto restart is disabled. This is because people on windows tend to double click the start.bat instead of opening a terminal and running the script from there, which causes the terminal to close when the server stops without giving the user the option to look at e.g. crash logs, i have noticed a lot of people on the discord server just saying "my server stops without any crash log" because of this exact reason.