### PR TITLE
Retitle plugin YML page to specifically mention Bukkit

### DIFF
--- a/docs/paper/dev/getting-started/plugin-yml.mdx
+++ b/docs/paper/dev/getting-started/plugin-yml.mdx
@@ -3,7 +3,7 @@ slug: /dev/plugin-yml
 description: A guide to Bukkit's plugin.yml file.
 ---
 
-# Plugin YML
+# Bukkit Plugin YML
 
 The `plugin.yml` file is the main configuration file for your plugin.
 It contains information about your plugin, such as its name, version, and description.


### PR DESCRIPTION
Considering that Paper plugins are the new hotness, we should probably distinguish the old Bukkit plugin YMLs from the new paper-plugin.yml, especially considering that a plain 'Plugin YML' page on the 'Paper' site lends itself to assuming 'Paper Plugin YML' is what the page describes, despite that being not the case.