### PR TITLE
Document various 1.20.5 config changes

### DIFF
--- a/config-specs/paper/server-properties.yml
+++ b/config-specs/paper/server-properties.yml
@@ -1,3 +1,6 @@
+accept-transfers:
+  default: "false"
+  description: "Whether this server accepts transfers from other servers using the transfer command/packet. If this is set to false, the server will disconnect the client."
 allow-flight:
   default: "false"
   description: >
@@ -167,6 +170,11 @@ rcon.password:
 rcon.port:
   default: "25575"
   description: "The port to start the rcon server on."
+region-file-compression:
+  default: "deflate"
+  description: >
+    Specifies the compression type used to compress region files. Possible values are: "deflate", "lz4" and "none".
+    If set to "none", region files will take up significantly more disk space, but it might make sense together with filesystem-level compression.
 require-resource-pack:
   default: "false"
   description: "If true, a player must have the given resource pack to connect. They will be kicked if they do not have it."

--- a/docs/paper/dev/getting-started/plugin-yml.mdx
+++ b/docs/paper/dev/getting-started/plugin-yml.mdx
@@ -92,8 +92,8 @@ This will be shown in the plugin info commands.
 
 The version of the Paper API that your plugin is using. This doesn't include the minor version.
 Servers with a version lower than the version specified here will refuse to load the plugin.
-The valid versions are 1.13 - <SoftwareVersion versionType={"maj"}/>.
-- <VersionFormattedCode>`api-version: '%%_MAJ_MC_%%'`</VersionFormattedCode>
+The valid versions are 1.13 - <SoftwareVersion versionType={"maj-min"}/>.
+- <VersionFormattedCode>`api-version: '%%_MAJ_MIN_MC_%%'`</VersionFormattedCode>
 
 :::info
 


### PR DESCRIPTION
For now, I added the 2 new `server.properties` entries and `plugin.yml` now accepts patches in their `api-version` field. Let me know if i missed something.

Blocked until 1.20.5 ready. 