### PR TITLE
Update api-version usage with minor version support.

### DIFF
--- a/docs/paper/dev/getting-started/plugin-yml.mdx
+++ b/docs/paper/dev/getting-started/plugin-yml.mdx
@@ -90,7 +90,7 @@ This will be shown in the plugin info commands.
 
 ### api-version
 
-The version of the Paper API that your plugin is using. This doesn't include the minor version until 1.20.5. From 1.20.5 and onward a minor version is supported.
+The version of the Paper API that your plugin is using. This doesn't include the minor version until 1.20.5. From 1.20.5 and onward, a minor version is supported.
 Servers with a version lower than the version specified here will refuse to load the plugin.
 The valid versions are 1.13 - <SoftwareVersion versionType={"maj-min-pat"}/>.
 - <VersionFormattedCode>`api-version: '%%_MAJ_MIN_PAT_MC_%%'`</VersionFormattedCode>

--- a/docs/paper/dev/getting-started/plugin-yml.mdx
+++ b/docs/paper/dev/getting-started/plugin-yml.mdx
@@ -90,7 +90,7 @@ This will be shown in the plugin info commands.
 
 ### api-version
 
-The version of the Paper API that your plugin is using. This doesn't include the minor version.
+The version of the Paper API that your plugin is using. This doesn't include the minor version until 1.20.5. From 1.20.5 and onward a minor version is supported.
 Servers with a version lower than the version specified here will refuse to load the plugin.
 The valid versions are 1.13 - <SoftwareVersion versionType={"maj-min-pat"}/>.
 - <VersionFormattedCode>`api-version: '%%_MAJ_MIN_PAT_MC_%%'`</VersionFormattedCode>


### PR DESCRIPTION
Spigot changed the api version in 1.20.5 and allows minor versions from there on. Since paper adapted this change the docs should reflect this, which they in fact already do. So the documentation is not coherent with the example already.

https://www.spigotmc.org/threads/spigot-bungeecord-1-20-5-1-20-6.645069/#post-4722247

![image](https://github.com/PaperMC/docs/assets/46890129/36c2fd75-3d7d-4641-bcf5-1d270e7ae67a)
