### PR TITLE
Fix: Incorrectly defined task in paper/dev/userdev

### DIFF
--- a/docs/paper/dev/getting-started/userdev.mdx
+++ b/docs/paper/dev/getting-started/userdev.mdx
@@ -106,7 +106,7 @@ The `-dev-all.jar` file in `build/libs` is the shaded, but not re-obfuscated JAR
 You can make the `reobfJar` task run on the default `build` task with:
 ```kotlin
 tasks.assemble {
-    dependsOn(reobfJar)
+    dependsOn(tasks.reobfJar)
 }
 ```
 


### PR DESCRIPTION
When looking through the docs and trying to get the userdev plugin to work I noticed this line being faulty.
This PR updates it to reflect the actual code one has to write.

Based on https://discord.com/channels/289587909051416579/1078993196924813372/1252988263073972294 (Message link in the papermc discord server)