### PR TITLE
fix: correct base URL for Pages deployments

### DIFF
--- a/.github/workflows/deploy-pr.yaml
+++ b/.github/workflows/deploy-pr.yaml
@@ -27,6 +27,9 @@ jobs:
         run: "pnpm install"
       - name: "build"
         run: "pnpm run build"
+        env:
+          CI_ENV: preview
+          GITHUB_PR_HEAD_OWNER: ${{ github.event.pull_request.head.repo.owner.login }}
       - name: "copy cloudflare configuration files to build directory"
         run: |
           cp _headers build/

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -28,6 +28,8 @@ jobs:
         run: "pnpm install"
       - name: "build"
         run: "pnpm run build"
+        env:
+          CI_ENV: production
       - name: "copy cloudflare configuration files to build directory"
         run: |
           cp _headers build/

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -13,13 +13,12 @@ import {
   cacheAuthorData,
   getFileCommitHashSafe,
 } from "./src/util/authorUtils";
+import { preview, deploymentID } from "./src/util/pagesUtils";
 
-const preview = isCI && env.CI_ENV === "preview";
 cacheAuthorData(preview || env.NODE_ENV === "development");
 
-const pagesId =
-  `${env.GITHUB_PR_HEAD_OWNER}-${env.GITHUB_HEAD_REF || env.GITHUB_REF_NAME}`.substring(0, 28);
-const url = (preview && `https://${pagesId}.papermc-docs.pages.dev`) || "https://docs.papermc.io";
+const url =
+  (preview && `https://${deploymentID}.papermc-docs.pages.dev`) || "https://docs.papermc.io";
 
 const docsCommon: Options = {
   breadcrumbs: true,

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -14,10 +14,12 @@ import {
   getFileCommitHashSafe,
 } from "./src/util/authorUtils";
 
-const preview = env.CF_PAGES_BRANCH !== "main";
-cacheAuthorData(preview || process.env.NODE_ENV === "development");
+const preview = isCI && env.CI_ENV === "preview";
+cacheAuthorData(preview || env.NODE_ENV === "development");
 
-const url = (preview && `https://${env.CF_PAGES_URL}`) || "https://docs.papermc.io";
+const pagesId =
+  `${env.GITHUB_PR_HEAD_OWNER}-${env.GITHUB_HEAD_REF || env.GITHUB_REF_NAME}`.substring(0, 28);
+const url = (preview && `https://${pagesId}.papermc-docs.pages.dev`) || "https://docs.papermc.io";
 
 const docsCommon: Options = {
   breadcrumbs: true,

--- a/src/util/pagesUtils.ts
+++ b/src/util/pagesUtils.ts
@@ -1,0 +1,11 @@
+import { env } from "process";
+
+export const preview = env.CI_ENV === "preview";
+
+export const deploymentID: string =
+  `${env.GITHUB_PR_HEAD_OWNER}-${env.GITHUB_HEAD_REF || env.GITHUB_REF_NAME}` // <PR head branch owner username>-<head branch name>
+    .substring(0, 28) // capped to 28 characters
+    .toLowerCase() // lowercase
+    .replace("/", "-") // sanitize characters in branch names
+    .replace("_", "-")
+    .replace(".", "-");


### PR DESCRIPTION
Fixes broken metadata and makes the sitemap generate once again. To me, it seems like there's no way to get a deployment URL at build time, so this PR tries to guess it for previews.

Based on my observations, deployment URLs are formatted in the `https://<id>.papermc-docs.pages.dev` format, where `<id>` is a `<PR head branch owner>-<branch name>` identifier capped to 28 characters and special characters (`/`, `_`, `.`) replaced with a dash.
Examples:
 - `https://papermc-feat-add-trial-chamb.papermc-docs.pages.dev`
 - `https://zlataovce-fix-highlight-cont.papermc-docs.pages.dev`
 - `https://papermc-121.papermc-docs.pages.dev`