### PR TITLE
document anti-xray bypass permission

### DIFF
--- a/docs/paper/admin/how-to/anti-xray.mdx
+++ b/docs/paper/admin/how-to/anti-xray.mdx
@@ -415,7 +415,7 @@ have enabled Anti-Xray:
 * Anti-Xray cannot hide ores exposed to air or other transparent blocks (in caves for example). In
   principle this is also the case for `engine-mode: 2` and `engine-mode: 3`, however, usually the fake ores obstruct the
   view of real blocks. Hiding those exposed ores too requires additional plugins.
-* The `use-permission` option is enabled and you have the Anti-Xray bypass permission or you have
+* The `use-permission` option is enabled and you have the Anti-Xray bypass permission (`paper.antixray.bypass`) or you have
   operator status.
 * The block type is missing in the configured block lists. This can be the result of using an
   outdated configuration file.


### PR DESCRIPTION
I'm unsure if I've put it in the correct place, but the bypass anti-xray permission node appears to be undocumented