### PR TITLE
Update server-properties.yml with new keys and minor correction elsewhere

### DIFF
--- a/config-specs/paper/server-properties.yml
+++ b/config-specs/paper/server-properties.yml
@@ -186,7 +186,7 @@ resource-pack:
   description: "The URL to the server's resource pack. "
 resource-pack-id:
   default: ""
-  description: "The UUID of the server resource pack to use. "
+  description: "The UUID of the server resource pack to use."
 resource-pack-prompt:
   default: ""
   description: "The message that is displayed when the client is prompted to download the resource pack."

--- a/config-specs/paper/server-properties.yml
+++ b/config-specs/paper/server-properties.yml
@@ -15,6 +15,9 @@ broadcast-console-to-ops:
 broadcast-rcon-to-ops:
   default: "true"
   description: "Send rcon command output to all online operators."
+bug-report-link:
+  default: ""
+  description: "A URL value creates and populates a Report Server Bugs button in the Server Links menu"
 debug:
   default: "false"
   description: "Enables the server's debug mode."
@@ -181,6 +184,9 @@ require-resource-pack:
 resource-pack:
   default: ""
   description: "The URL to the server's resource pack. "
+resource-pack-id:
+  default: ""
+  description: "The UUID of the server resource pack to use. "
 resource-pack-prompt:
   default: ""
   description: "The message that is displayed when the client is prompted to download the resource pack."

--- a/config-specs/paper/server-properties.yml
+++ b/config-specs/paper/server-properties.yml
@@ -17,7 +17,7 @@ broadcast-rcon-to-ops:
   description: "Send rcon command output to all online operators."
 bug-report-link:
   default: ""
-  description: "A URL value creates and populates a Report Server Bugs button in the Server Links menu"
+  description: "A URL value used for the Report Server Bugs button in the Server Links client menu."
 debug:
   default: "false"
   description: "Enables the server's debug mode."

--- a/src/components/config/ConfigurationStructureDiagram.tsx
+++ b/src/components/config/ConfigurationStructureDiagram.tsx
@@ -20,7 +20,7 @@ const folderData: ExplorerNode[] = [
     name: "logs",
     type: "folder",
     description:
-      "This folder contains all the logs for the server. It compresses old logs into .gz files, but holds the most recent log as a .txt file.",
+      "This folder contains all the logs for the server. It compresses old logs into .gz files, but holds the most recent log as a latest.log file.",
   },
   {
     name: "config",


### PR DESCRIPTION
`resource-pack-id` usage found through https://minecraft.wiki/w/Resource_pack and `bug-report-link` usage found through my own testing.
Also corrects the information for the `logs/` directory in the Paper Configuration page component.


Closes #425 