### PR TITLE
Added note that the docs are incomplete for the Commands API

### DIFF
--- a/docs/paper/dev/api/commands.mdx
+++ b/docs/paper/dev/api/commands.mdx
@@ -8,6 +8,14 @@ description: A guide to Paper's Brigadier command API.
 Paper's command system is built on top of Minecraft's Brigadier command system. This system is a
 powerful and flexible way to define commands and arguments.
 
+:::note
+
+As this documentation is incomplete at the moment, see [the test Paper plugin](https://github.com/PaperMC/Paper/tree/master/test-plugin) 
+in the project's main repository for information on how to use Paper Brigadier commands. 
+And don't worry, this page is currently being worked on.
+
+:::
+
 :::danger[Experimental]
 
 Paper's command system is still experimental and may change in the future.


### PR DESCRIPTION
The Commands API Page in the docs is currently incomplete and/or not detailed especially when it comes to Arguments/Argument types, so I added a note for that while I'm working on expanding the docs