### PR TITLE
Remove some Waterfall references

### DIFF
--- a/docs/misc/hangar-publishing.md
+++ b/docs/misc/hangar-publishing.md
@@ -67,6 +67,7 @@ Hangar allows version ranges (such as `1.19-1.20.2`) and wildcards (such as `1.2
 # TODO: Remove the platforms you don't need and put in the correct versions.
 paperVersion=1.12.2, 1.16.5, 1.19-1.20.2
 velocityVersion=3.2
+waterfallVersion=1.20
 ```
 
 ### `build.gradle.kts`
@@ -81,7 +82,7 @@ plugins {
 
 Then you simply need to add the `hangarPublish` configuration block and make sure you do the following:
 
-- If your plugin is not a Paper plugin, or supports Velocity as well, copy the register block with a different
+- If your plugin is not a Paper plugin, or supports Velocity/Waterfall as well, copy the register block with a different
   platform and change the property used instead of `paperVersion` (as declared in the `gradle.properties` file).
 - Insert the correct project namespace
 - Insert your plugin dependencies, if any

--- a/docs/misc/hangar-publishing.md
+++ b/docs/misc/hangar-publishing.md
@@ -62,12 +62,11 @@ versions.
 Hangar allows version ranges (such as `1.19-1.20.2`) and wildcards (such as `1.20.x`).
 
 ```properties
-# Specify the platform versions for Paper, Velocity, and Waterfall.
+# Specify the platform versions for Paper and Velocity.
 # Hangar also allows version ranges (such as 1.19-1.20.2) and wildcards (such as 1.20.x).
 # TODO: Remove the platforms you don't need and put in the correct versions.
 paperVersion=1.12.2, 1.16.5, 1.19-1.20.2
 velocityVersion=3.2
-waterfallVersion=1.20
 ```
 
 ### `build.gradle.kts`
@@ -82,7 +81,7 @@ plugins {
 
 Then you simply need to add the `hangarPublish` configuration block and make sure you do the following:
 
-- If your plugin is not a Paper plugin, or supports Velocity/Waterfall as well, copy the register block with a different
+- If your plugin is not a Paper plugin, or supports Velocity as well, copy the register block with a different
   platform and change the property used instead of `paperVersion` (as declared in the `gradle.properties` file).
 - Insert the correct project namespace
 - Insert your plugin dependencies, if any

--- a/docs/misc/java-install.md
+++ b/docs/misc/java-install.md
@@ -4,8 +4,8 @@ description: How to install or update to Java 21 on Linux (apt/rpm), Windows, or
 toc_max_heading_level: 5
 ---
 
-Installing Java is a critical first step to using or developing plugins for Paper, Velocity, and
-Waterfall. This guide will walk you through the recommended installation steps for most major
+Installing Java is a critical first step to using or developing plugins for Paper, Velocity. 
+This guide will walk you through the recommended installation steps for most major
 platforms.
 
 :::caution[Do not use headless variants of Java!]

--- a/docs/misc/java-install.md
+++ b/docs/misc/java-install.md
@@ -4,7 +4,7 @@ description: How to install or update to Java 21 on Linux (apt/rpm), Windows, or
 toc_max_heading_level: 5
 ---
 
-Installing Java is a critical first step to using or developing plugins for Paper, Velocity. 
+Installing Java is a critical first step to using or developing plugins for Paper and Velocity. 
 This guide will walk you through the recommended installation steps for most major
 platforms.
 

--- a/docs/velocity/admin/getting-started/faq.mdx
+++ b/docs/velocity/admin/getting-started/faq.mdx
@@ -17,7 +17,7 @@ Velocity 3.3.x requires Java <Property name="VELOCITY_JAVA_MIN" /> or above.
 A good source for finding plugins compatible with Velocity would be our plugin repository
 [Hangar](https://hangar.papermc.io/?page=0&platform=VELOCITY).
 
-## Does Velocity support plugins developed for BungeeCord or Waterfall?
+## Does Velocity support plugins developed for BungeeCord?
 
 No. Many of the things Velocity can do could not be done if we decided to support BungeeCord
 plugins.

--- a/docs/velocity/admin/getting-started/faq.mdx
+++ b/docs/velocity/admin/getting-started/faq.mdx
@@ -17,7 +17,7 @@ Velocity 3.3.x requires Java <Property name="VELOCITY_JAVA_MIN" /> or above.
 A good source for finding plugins compatible with Velocity would be our plugin repository
 [Hangar](https://hangar.papermc.io/?page=0&platform=VELOCITY).
 
-## Does Velocity support plugins developed for BungeeCord?
+## Does Velocity support plugins developed for BungeeCord or Waterfall?
 
 No. Many of the things Velocity can do could not be done if we decided to support BungeeCord
 plugins.

--- a/docs/velocity/admin/reference/server-compatibility.mdx
+++ b/docs/velocity/admin/reference/server-compatibility.mdx
@@ -83,7 +83,7 @@ improves proxy support in general.
 Velocity does not support Forge-Bukkit hybrids - they have caused several issues, and the design of
 the Bukkit API precludes any notion of sane mod support.
 
-## Proxy-behind-proxy (BungeeCord/Waterfall, Velocity, ...)
+## Proxy-behind-proxy (BungeeCord, Velocity, ...)
 
 These setups are _completely unsupported_. You are best advised to avoid them, as they can cause
 lots of issues. Most proxy-behind-proxy setups are either illogical in the first place or can be

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -33,7 +33,7 @@ const docsCommon: Options = {
 const config: Config = {
   title: "PaperMC Docs",
   tagline:
-    "Documentation for all projects under the PaperMC umbrella, including Paper, Velocity, and Waterfall.",
+    "Documentation for all projects under the PaperMC umbrella, including Paper, Velocity, and Folia.",
   url: url,
   baseUrl: "/",
   onBrokenLinks: isCI ? "throw" : "warn",


### PR DESCRIPTION
Since Waterfall went EoL for quite some time now I believe it shouldn't be mentioned in examples/documentations anymore. I also replaced Waterfall->Folia in the main page's description since I think it became more important than Waterfall over time.