### PR TITLE
fix: show search results only from the active project

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,11 +70,12 @@
       "last 1 safari version"
     ]
   },
-  "packageManager": "pnpm@9.2.0+sha256.94fab213df221c55b6956b14a2264c21c6203cca9f0b3b95ff2fe9b84b120390",
+  "packageManager": "pnpm@9.5.0+sha512.140036830124618d624a2187b50d04289d5a087f326c9edfc0ccd733d76c4f52c3a313d4fc148794a2a9d81553016004e6742e8cf850670268a7387fc220c903",
   "pnpm": {
     "patchedDependencies": {
       "@docusaurus/plugin-content-docs@3.4.0": "patches/@docusaurus__plugin-content-docs@3.4.0.patch",
-      "@docusaurus/utils@3.4.0": "patches/@docusaurus__utils@3.4.0.patch"
+      "@docusaurus/utils@3.4.0": "patches/@docusaurus__utils@3.4.0.patch",
+      "@docusaurus/theme-common@3.4.0": "patches/@docusaurus__theme-common@3.4.0.patch"
     }
   }
 }

--- a/patches/@docusaurus__theme-common@3.4.0.patch
+++ b/patches/@docusaurus__theme-common@3.4.0.patch
@@ -1,0 +1,26 @@
+diff --git a/lib/utils/searchUtils.js b/lib/utils/searchUtils.js
+index 298fa256922abc626cd5a04a5cc2b686fb1867ca..910131ce57fbbc9ac7231ff9b0622618ce6f4023 100755
+--- a/lib/utils/searchUtils.js
++++ b/lib/utils/searchUtils.js
+@@ -37,7 +37,7 @@ export function useContextualSearchFilters() {
+     }
+     const tags = [
+         DEFAULT_SEARCH_TAG,
+-        ...Object.keys(allDocsData).map(getDocPluginTags),
++        ...(activePluginAndVersion ? [activePluginAndVersion.activePlugin.pluginId] : Object.keys(allDocsData)).map(getDocPluginTags),
+     ];
+     return {
+         locale: i18n.currentLocale,
+diff --git a/src/utils/searchUtils.ts b/src/utils/searchUtils.ts
+index 082f0fb7085ca191a03360bff0bdb3758c046db7..9151b9691e7ab9954407b73bc8f51f0a2dc67c40 100755
+--- a/src/utils/searchUtils.ts
++++ b/src/utils/searchUtils.ts
+@@ -56,7 +56,7 @@ export function useContextualSearchFilters(): {locale: string; tags: string[]} {
+
+   const tags = [
+     DEFAULT_SEARCH_TAG,
+-    ...Object.keys(allDocsData).map(getDocPluginTags),
++    ...(activePluginAndVersion ? [activePluginAndVersion.activePlugin.pluginId] : Object.keys(allDocsData)).map(getDocPluginTags),
+   ];
+
+   return {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ patchedDependencies:
   '@docusaurus/plugin-content-docs@3.4.0':
     hash: gecwzkrhj7cwrb73odjk2lxlse
     path: patches/@docusaurus__plugin-content-docs@3.4.0.patch
+  '@docusaurus/theme-common@3.4.0':
+    hash: cowxp5xcabdrx3sdjfqtxcjvce
+    path: patches/@docusaurus__theme-common@3.4.0.patch
   '@docusaurus/utils@3.4.0':
     hash: fj4flwdloktwsjj7beb2cdhvvm
     path: patches/@docusaurus__utils@3.4.0.patch
@@ -39,7 +42,7 @@ importers:
         version: 3.4.0(@types/react@18.2.79)(esbuild@0.20.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)
       '@docusaurus/theme-common':
         specifier: 3.4.0
-        version: 3.4.0(@docusaurus/types@3.4.0(esbuild@0.20.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(esbuild@0.20.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)
+        version: 3.4.0(patch_hash=cowxp5xcabdrx3sdjfqtxcjvce)(@docusaurus/types@3.4.0(esbuild@0.20.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(esbuild@0.20.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)
       '@docusaurus/theme-mermaid':
         specifier: 3.4.0
         version: 3.4.0(esbuild@0.20.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)
@@ -6987,7 +6990,7 @@ snapshots:
       '@babel/preset-env': 7.24.7(@babel/core@7.24.7)
       '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(esbuild@0.20.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(esbuild@0.20.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)
       '@docusaurus/logger': 3.4.0
-      '@docusaurus/theme-common': 3.4.0(@docusaurus/types@3.4.0(esbuild@0.20.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(esbuild@0.20.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)
+      '@docusaurus/theme-common': 3.4.0(patch_hash=cowxp5xcabdrx3sdjfqtxcjvce)(@docusaurus/types@3.4.0(esbuild@0.20.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(esbuild@0.20.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)
       '@docusaurus/theme-translations': 3.4.0
       '@docusaurus/types': 3.4.0(esbuild@0.20.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@docusaurus/utils': 3.4.0(patch_hash=fj4flwdloktwsjj7beb2cdhvvm)(@docusaurus/types@3.4.0(esbuild@0.20.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(esbuild@0.20.2)(typescript@5.4.5)
@@ -7068,7 +7071,7 @@ snapshots:
       '@docusaurus/plugin-content-blog': 3.4.0(esbuild@0.20.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)
       '@docusaurus/plugin-content-docs': 3.4.0(patch_hash=gecwzkrhj7cwrb73odjk2lxlse)(esbuild@0.20.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)
       '@docusaurus/plugin-content-pages': 3.4.0(esbuild@0.20.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)
-      '@docusaurus/theme-common': 3.4.0(@docusaurus/types@3.4.0(esbuild@0.20.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(esbuild@0.20.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)
+      '@docusaurus/theme-common': 3.4.0(patch_hash=cowxp5xcabdrx3sdjfqtxcjvce)(@docusaurus/types@3.4.0(esbuild@0.20.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(esbuild@0.20.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)
       '@docusaurus/theme-translations': 3.4.0
       '@docusaurus/types': 3.4.0(esbuild@0.20.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@docusaurus/utils': 3.4.0(patch_hash=fj4flwdloktwsjj7beb2cdhvvm)(@docusaurus/types@3.4.0(esbuild@0.20.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(esbuild@0.20.2)(typescript@5.4.5)
@@ -7108,7 +7111,7 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/theme-common@3.4.0(@docusaurus/types@3.4.0(esbuild@0.20.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(esbuild@0.20.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)':
+  '@docusaurus/theme-common@3.4.0(patch_hash=cowxp5xcabdrx3sdjfqtxcjvce)(@docusaurus/types@3.4.0(esbuild@0.20.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(esbuild@0.20.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)':
     dependencies:
       '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(esbuild@0.20.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(esbuild@0.20.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)
       '@docusaurus/module-type-aliases': 3.4.0(esbuild@0.20.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -7150,7 +7153,7 @@ snapshots:
     dependencies:
       '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(esbuild@0.20.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(esbuild@0.20.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)
       '@docusaurus/module-type-aliases': 3.4.0(esbuild@0.20.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@docusaurus/theme-common': 3.4.0(@docusaurus/types@3.4.0(esbuild@0.20.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(esbuild@0.20.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)
+      '@docusaurus/theme-common': 3.4.0(patch_hash=cowxp5xcabdrx3sdjfqtxcjvce)(@docusaurus/types@3.4.0(esbuild@0.20.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(esbuild@0.20.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)
       '@docusaurus/types': 3.4.0(esbuild@0.20.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(esbuild@0.20.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(esbuild@0.20.2)(typescript@5.4.5)
       mermaid: 10.9.1
@@ -7181,7 +7184,7 @@ snapshots:
       '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(esbuild@0.20.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(esbuild@0.20.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)
       '@docusaurus/logger': 3.4.0
       '@docusaurus/plugin-content-docs': 3.4.0(patch_hash=gecwzkrhj7cwrb73odjk2lxlse)(esbuild@0.20.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)
-      '@docusaurus/theme-common': 3.4.0(@docusaurus/types@3.4.0(esbuild@0.20.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(esbuild@0.20.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)
+      '@docusaurus/theme-common': 3.4.0(patch_hash=cowxp5xcabdrx3sdjfqtxcjvce)(@docusaurus/types@3.4.0(esbuild@0.20.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(esbuild@0.20.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)
       '@docusaurus/theme-translations': 3.4.0
       '@docusaurus/utils': 3.4.0(patch_hash=fj4flwdloktwsjj7beb2cdhvvm)(@docusaurus/types@3.4.0(esbuild@0.20.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(esbuild@0.20.2)(typescript@5.4.5)
       '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(esbuild@0.20.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(esbuild@0.20.2)(typescript@5.4.5)


### PR DESCRIPTION
Makes the search bar display results only from the currently opened project.
This should have no effect on non-project pages, such as the main or search page; results from all projects should still be displayed there.