### PR TITLE
fix: using-databases jdbc url for mysql

### DIFF
--- a/docs/paper/dev/misc/databases.mdx
+++ b/docs/paper/dev/misc/databases.mdx
@@ -135,7 +135,7 @@ public class DatabaseManager {
 
     public void connect() {
         HikariConfig config = new HikariConfig();
-        config.setJdbcUrl("jdbc://mysql://localhost:3306/mydatabase"); // Address of your running MySQL database
+        config.setJdbcUrl("jdbc:mysql://localhost:3306/mydatabase"); // Address of your running MySQL database
         config.setUsername("username"); // Username
         config.setPassword("password"); // Password
         config.setMaximumPoolSize(10); // Pool size defaults to 10


### PR DESCRIPTION
This PR fixes a mistake made in the JDBC url from the "Using Databases" page on the "Simple MySQL Setup" dropdown.

From ``jdbc://mysql://localhost:3306/mydatabase`` to ``jdbc:mysql://localhost:3306/mydatabase``.

I just removed the two ``//`` after ``jdbc:``, according to the Microsoft documentation [Building the connection URL](https://learn.microsoft.com/en-us/sql/connect/jdbc/building-the-connection-url?view=sql-server-ver16):

``jdbc:sqlserver://[serverName[\instanceName][:portNumber]][;property=value[;property=value]]``.