### PR TITLE
fix(security): PR Previews from Forks

### DIFF
--- a/.github/workflows/build-preview.yaml
+++ b/.github/workflows/build-preview.yaml
@@ -13,6 +13,8 @@ jobs:
         uses: "actions/checkout@v4"
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: "setup pnpm"
         uses: "pnpm/action-setup@v4"
       - name: "setup node"
@@ -31,7 +33,6 @@ jobs:
         run: |
           cp _headers build/
           cp _redirects build/
-      # Uploads the build directory as a workflow artifact
       - name: "upload build artifact"
         uses: "actions/upload-artifact@v4"
         with:

--- a/.github/workflows/build-preview.yaml
+++ b/.github/workflows/build-preview.yaml
@@ -1,21 +1,18 @@
-name: "Deploy to Cloudflare Pages (Preview)"
+name: "Build Preview Deployment"
 
-on: [pull_request_target]
+on:
+  pull_request:
+    types: [opened, synchronize]
 
 jobs:
-  deploy:
+  build-preview:
     runs-on: "ubuntu-latest"
-    permissions:
-      contents: read
-      deployments: write
-      pull-requests: write
+    name: "Build Preview Site and Upload Build Artifact"
     steps:
       - name: "checkout"
         uses: "actions/checkout@v4"
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: "setup pnpm"
         uses: "pnpm/action-setup@v4"
       - name: "setup node"
@@ -34,13 +31,9 @@ jobs:
         run: |
           cp _headers build/
           cp _redirects build/
-      - name: "publish (push)"
-        id: "cloudflare-publish"
-        uses: "AdrianGonz97/refined-cf-pages-action@v1"
+      # Uploads the build directory as a workflow artifact
+      - name: "upload build artifact"
+        uses: "actions/upload-artifact@v4"
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: "papermc-docs"
-          deploymentName: "Preview"
-          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
-          directory: "build"
+          name: "preview-build"
+          path: "build"

--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -1,4 +1,5 @@
-name: "Upload Preview Deployment"
+name: "Publish Preview Deployment"
+
 on:
   workflow_run:
     workflows: ["Build Preview Deployment"]
@@ -7,8 +8,8 @@ on:
 
 permissions:
   actions: read
-  deployments: write
   contents: read
+  deployments: write
   pull-requests: write
 
 jobs:
@@ -17,7 +18,6 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     name: "Deploy Preview to Cloudflare Pages"
     steps:
-      # Downloads the build directory from the previous workflow
       - name: "Download build artifact"
         uses: "actions/download-artifact@v4"
         id: "preview-build-artifact"
@@ -26,7 +26,6 @@ jobs:
           path: "build"
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
-
       - name: "Deploy to Cloudflare Pages"
         uses: "AdrianGonz97/refined-cf-pages-action@v1"
         with:

--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -1,0 +1,38 @@
+name: "Upload Preview Deployment"
+on:
+  workflow_run:
+    workflows: ["Build Preview Deployment"]
+    types:
+      - completed
+
+permissions:
+  actions: read
+  deployments: write
+  contents: read
+  pull-requests: write
+
+jobs:
+  deploy-preview:
+    runs-on: "ubuntu-latest"
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    name: "Deploy Preview to Cloudflare Pages"
+    steps:
+      # Downloads the build directory from the previous workflow
+      - name: "Download build artifact"
+        uses: "actions/download-artifact@v4"
+        id: "preview-build-artifact"
+        with:
+          name: "preview-build"
+          path: "build"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: "Deploy to Cloudflare Pages"
+        uses: "AdrianGonz97/refined-cf-pages-action@v1"
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          projectName: "papermc-docs"
+          deploymentName: "Preview"
+          directory: ${{ steps.preview-build-artifact.outputs.download-path }}


### PR DESCRIPTION
## The Issue

Hey! I'm the maintainer of the Github Action [refined-cf-pages-action](https://github.com/AdrianGonz97/refined-cf-pages-action) and we were recently made aware of a security vulnerability regarding the `pull_request_target` workflow event where it's possible to leak secrets (including the CF credentials used in the action) through a Github Actions exploit when running untrusted code. Unfortunately, our previous recommendation for the setup of the _PR Previews from Forks_ feature included the use of this workflow event type without PR approvals, which [has now been updated](https://github.com/AdrianGonz97/refined-cf-pages-action#enabling-pr-previews-from-forks). 

I'm going around to all of the dependents of the action that are using the _PR Previews from Forks_ feature to apply the fix.

## The Fix

We've come up with an alternate method that is safer to use and will resolve this issue entirely. 

Rather than using `pull_request_target`, which runs in a privileged environment (meaning that repository secrets can be used in it), previews will now be deployed in two stages:

1. The first stage (`build-preview.yml`) will use the `pull_request` event, which runs in an unprivileged environment, making it safe to run untrusted code. The site will be built in this stage and the build directory will be uploaded to Github as an [artifact](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/storing-workflow-data-as-artifacts).
2. The second stage (`deploy-preview.yml`) will use the `workflow_run` event, which runs in a privileged environment where its only job will be to download the build artifact and then run the `refined-cf-pages-action` action to upload the build files to Cloudflare Pages for preview deployment.

---

And that's it! No further actions are necessary. 

Thanks for your time!