### PR TITLE
Document methods to resolve issues with Gradle in Groovy

### DIFF
--- a/docs/paper/dev/getting-started/userdev.mdx
+++ b/docs/paper/dev/getting-started/userdev.mdx
@@ -148,6 +148,6 @@ This is useful for plugins that have loaders for both Spigot and Paper and want 
 
 :::note
 
-If you are using Gradle with Groovy syntax, you should call the mangled static method like `getMOJANG_PRODUCTION()`.
+If you are using Gradle with the Groovy DSL, you should instead access the fields via static method like `getMOJANG_PRODUCTION()`.
 
 :::

--- a/docs/paper/dev/getting-started/userdev.mdx
+++ b/docs/paper/dev/getting-started/userdev.mdx
@@ -148,6 +148,6 @@ This is useful for plugins that have loaders for both Spigot and Paper and want 
 
 :::note
 
-If you are using Gradle with the Groovy DSL, you should instead access the fields via static method like `getMOJANG_PRODUCTION()`.
+If you are using Gradle with the Groovy DSL, you should instead access the fields via static methods like `getMOJANG_PRODUCTION()`.
 
 :::

--- a/docs/paper/dev/getting-started/userdev.mdx
+++ b/docs/paper/dev/getting-started/userdev.mdx
@@ -136,6 +136,12 @@ If you want your main output to use Mojang mappings, you need to remove all `dep
 paperweight.reobfArtifactConfiguration = io.papermc.paperweight.userdev.ReobfArtifactConfiguration.MOJANG_PRODUCTION
 ```
 
+:::note
+
+If you are using Gradle with Groovy syntax, you should use the `getMOJANG_PRODUCTION()` static method instead of the `MOJANG_PRODUCTION` static member.
+
+:::
+
 ### Compiling to Spigot mappings
 
 If you want your main output to use Spigot mappings, add the following code to your build script:
@@ -143,5 +149,11 @@ If you want your main output to use Spigot mappings, add the following code to y
 ```kotlin title="build.gradle.kts"
 paperweight.reobfArtifactConfiguration = io.papermc.paperweight.userdev.ReobfArtifactConfiguration.REOBF_PRODUCTION
 ```
+
+:::note
+
+If you are using Gradle with Groovy syntax, you should use the `getREOBF_PRODUCTION()` static method instead of the `REOBF_PRODUCTION` static member.
+
+:::
 
 This is useful for plugins that have loaders for both Spigot and Paper and want to keep compatibility with both.

--- a/docs/paper/dev/getting-started/userdev.mdx
+++ b/docs/paper/dev/getting-started/userdev.mdx
@@ -136,12 +136,6 @@ If you want your main output to use Mojang mappings, you need to remove all `dep
 paperweight.reobfArtifactConfiguration = io.papermc.paperweight.userdev.ReobfArtifactConfiguration.MOJANG_PRODUCTION
 ```
 
-:::note
-
-If you are using Gradle with Groovy syntax, you should use the `getMOJANG_PRODUCTION()` static method instead of the `MOJANG_PRODUCTION` static member.
-
-:::
-
 ### Compiling to Spigot mappings
 
 If you want your main output to use Spigot mappings, add the following code to your build script:
@@ -150,10 +144,10 @@ If you want your main output to use Spigot mappings, add the following code to y
 paperweight.reobfArtifactConfiguration = io.papermc.paperweight.userdev.ReobfArtifactConfiguration.REOBF_PRODUCTION
 ```
 
+This is useful for plugins that have loaders for both Spigot and Paper and want to keep compatibility with both.
+
 :::note
 
-If you are using Gradle with Groovy syntax, you should use the `getREOBF_PRODUCTION()` static method instead of the `REOBF_PRODUCTION` static member.
+If you are using Gradle with Groovy syntax, you should call the mangled static method like `getMOJANG_PRODUCTION()`.
 
 :::
-
-This is useful for plugins that have loaders for both Spigot and Paper and want to keep compatibility with both.


### PR DESCRIPTION
When using `paperweight-userdev` with Gradle and Groovy syntax instead of Gradle Kotlin DSL, some modifications to the code described in the documentation are necessary.

I have added a note to the documentation regarding the issues I encountered and how to resolve them.