### PR TITLE
feat: add caution admonition for plugin loading phases in Velocity

### DIFF
--- a/docs/velocity/dev/getting-started/api-basics.mdx
+++ b/docs/velocity/dev/getting-started/api-basics.mdx
@@ -93,6 +93,8 @@ Dependencies on other plugins are also to be specified there, but we'll get to t
 
 ### A word of caution
 
+:::caution
+
 In Velocity, plugin loading is split into two steps: construction and initialization. The code in
 your plugin's constructor is part of the construction phase. There is very little you can do safely
 during construction, especially as the API does not specify which operations are safe to run during
@@ -113,6 +115,8 @@ public void onProxyInitialization(ProxyInitializeEvent event) {
     server.getEventManager().register(this, new PluginListener());
 }
 ```
+
+:::
 
 ## Getting your plugin's directory
 


### PR DESCRIPTION
Although the importance is already *considered* by adding it to the "Common Pitfalls", I believe it would help if this is marked as a *warning* to give people a heads-up.

Link to the original page: https://docs.papermc.io/velocity/dev/api-basics#a-word-of-caution
Link to the page: https://timongcraft-feat-velocity-ma.papermc-docs.pages.dev/velocity/dev/api-basics#a-word-of-caution