### PR TITLE
Update audience operation support details in Velocity

### DIFF
--- a/docs/velocity/dev/getting-started/pitfalls.mdx
+++ b/docs/velocity/dev/getting-started/pitfalls.mdx
@@ -33,5 +33,5 @@ public void onProxyInitialization(ProxyInitializeEvent event) {
 
 ## Audience operations not supported
 
-Velocity only supports sending chat messages, action bar messages, titles, and bossbars through the
-Adventure API. No other operations are supported.
+Velocity only supports sending chat messages, action bar messages, titles, bossbars, tablist header and footer, and resource packs through the
+Adventure API. All other operations, such as sound and book operations, are not supported.

--- a/docs/velocity/dev/getting-started/pitfalls.mdx
+++ b/docs/velocity/dev/getting-started/pitfalls.mdx
@@ -33,6 +33,9 @@ public void onProxyInitialization(ProxyInitializeEvent event) {
 
 ## Audience operations are not fully supported
 
+Velocity currently does not support all Audience operations of the Adventure API, so these operations should be handled on the backend.
+Furthermore, playing sound was previously considered infeasible, as for versions below 1.19.3, a registry of hardcoded sound IDs is required.
+
 | Operation                  | Supported |
 | -------------------------- | ----------|
 | Chat messages              | Yes       |

--- a/docs/velocity/dev/getting-started/pitfalls.mdx
+++ b/docs/velocity/dev/getting-started/pitfalls.mdx
@@ -31,7 +31,15 @@ public void onProxyInitialization(ProxyInitializeEvent event) {
 }
 ```
 
-## Audience operations not supported
+## Audience operations are not fully supported
 
-Velocity only supports sending chat messages, action bar messages, titles, bossbars, tablist header and footer, and resource packs through the
-Adventure API. All other operations, such as sound and book operations, are not supported.
+| Operation                  | Supported |
+| -------------------------- | ----------|
+| Chat messages              | Yes       |
+| Action bar messages        | Yes       |
+| Titles                     | Yes       |
+| Bossbars                   | Yes       |
+| Tablist header and footer  | Yes       |
+| Resource packs             | Yes       |
+| Sound                      | No        |
+| Book                       | No        |


### PR DESCRIPTION
- Documented support for tablist headers, footers, and resource packs.
- Clarified that unsupported operations include sounds and books. (currently the only unsupported operations)

Support for resource packs was added to the `ConnectedPlayer` class [here](https://github.com/PaperMC/Velocity/commit/cbd07b14349c449202e84a840da1167b42487cca#diff-1cd097c1de92fff8c43bc33eb4f52405eb5396f9e8cc922a4502e4cad12e1f88).
Support for the tablist header and footer was added [here](https://github.com/PaperMC/Velocity/commit/5da085d82f9cd7a91a4b8d44f6dc94dc3383b173#diff-1cd097c1de92fff8c43bc33eb4f52405eb5396f9e8cc922a4502e4cad12e1f88).

Link to the original page: https://docs.papermc.io/velocity/dev/pitfalls#audience-operations-not-supported
Link to the page: https://timongcraft-fix-audience-api.papermc-docs.pages.dev/velocity/dev/pitfalls#audience-operations-are-not-fully-supported