### PR TITLE
PDC Clarifications

### DIFF
--- a/docs/paper/dev/api/pdc.mdx
+++ b/docs/paper/dev/api/pdc.mdx
@@ -195,3 +195,7 @@ and their PDC can be fetched with <Javadoc name={"org.bukkit.persistence.Persist
     - `Structure#getPersistentDataContainer()`
 - ##### <Javadoc name={"org.bukkit.inventory.meta.ItemMeta"}>`ItemMeta`</Javadoc>
     - `ItemMeta#getPersistentDataContainer()`
+- ##### <Javadoc name={"org.bukkit.generator.structure.GeneratedStructure"}>`GeneratedStructure`</Javadoc>
+    - `GeneratedStructure#getPersistentDataContainer()`
+- ##### <Javadoc name={"org.bukkit.Raid"}>`Raid`</Javadoc>
+    - `Raid#getPersistentDataContainer()`

--- a/docs/paper/dev/api/pdc.mdx
+++ b/docs/paper/dev/api/pdc.mdx
@@ -164,7 +164,7 @@ container.set(key, new UUIDDataType(), uuid);
 
 ## Storing on different objects
 
-:::warning
+:::caution
 
 Data is **not** copied across holders for you, and needs to be **manually** copied if 'moving' between PersistentDataHolders.
 

--- a/docs/paper/dev/api/pdc.mdx
+++ b/docs/paper/dev/api/pdc.mdx
@@ -164,6 +164,14 @@ container.set(key, new UUIDDataType(), uuid);
 
 ## Storing on different objects
 
+:::warning
+
+Data is **not** copied across holders for you, and needs to be **manually** copied if 'moving' between PersistentDataHolders.
+
+E.g. Placing an ItemStack as a Block (with a TileState) ***does not*** copy over PDC data.
+
+:::
+
 Objects that can have a PDC implement the <Javadoc name={"org.bukkit.persistence.PersistentDataHolder"}>`PersistentDataHolder`</Javadoc> interface
 and their PDC can be fetched with <Javadoc name={"org.bukkit.persistence.PersistentDataHolder#getPersistentDataContainer()"}>`PersistentDataHolder#getPersistentDataContainer()`</Javadoc>.
 

--- a/docs/paper/dev/api/pdc.mdx
+++ b/docs/paper/dev/api/pdc.mdx
@@ -182,7 +182,7 @@ and their PDC can be fetched with <Javadoc name={"org.bukkit.persistence.Persist
 - ##### <Javadoc name={"org.bukkit.entity.Entity"}>`Entity`</Javadoc>
     - `Entity#getPersistentDataContainer()`
 - ##### <Javadoc name={"org.bukkit.block.TileState"}>`TileState`</Javadoc>
-    - This is slightly more complicated, as you need to cast the block to something that extends `TileState`.
+    - This is slightly more complicated, as you need to cast the block's state to something that extends `TileState`.
       This does not work for all blocks, only those that have a tile entity.
       ```java
         Block block = ...;


### PR DESCRIPTION
Several minor PDC clarifications
- Warning box for developers, clarifying that PDCs must be **manually** copied from holder to holder
- Correction of TileState explanation
- Adding of other PersistentDataHolders