### PR TITLE
Specify when loottable is removed for replenished

### DIFF
--- a/config-specs/paper/paper-world-defaults.yml
+++ b/config-specs/paper/paper-world-defaults.yml
@@ -864,8 +864,8 @@ lootables:
   retain-unlooted-shulker-box-loot-table-on-non-player-break:
     default: "true"
     description: >-
-      Configures if breaking a shulker box via non-player means e.g. a piston, should retain
-      the shulker boxes loot table if the shulker box has not been looted yet. Setting this option
+      Configures if breaking a shulker box via non-player means, e.g. a piston, should retain
+      the shulker box's loot table if the shulker box has not been looted yet. Setting this option
       to `false` prevents players from moving shulker boxes with potentially refilling loot tables
       to new locations by breaking them via the likes of pistons.
 maps:

--- a/config-specs/paper/paper-world-defaults.yml
+++ b/config-specs/paper/paper-world-defaults.yml
@@ -827,7 +827,8 @@ lootables:
     description: >-
       Instructs the server to automatically replenish lootable containers. This
       feature is useful for long-term worlds in which players are not expected
-      to constantly explore to generate new chunks
+      to constantly explore to generate new chunks. Breaking such lootable containers
+      disables replenishing after their initial looting.
   max-refills:
     default: "-1"
     description: >-

--- a/config-specs/paper/paper-world-defaults.yml
+++ b/config-specs/paper/paper-world-defaults.yml
@@ -861,6 +861,13 @@ lootables:
     description: >-
       Per-player cooldown between reloots. Formatted as a duration with a single
       unit e.g. 10h or 25m. Supports d, h, m, and s.
+  retain-unlooted-shulker-box-loot-table-on-non-player-break:
+    default: "true"
+    description: >-
+      Configures if breaking a shulker box via non-player means e.g. a piston, should retain
+      the shulker boxes loot table if the shulker box has not been looted yet. Setting this option
+      to `false` prevents players from moving shulker boxes with potentially refilling loot tables
+      to new locations by breaking them via the likes of pistons.
 maps:
   item-frame-cursor-limit:
     default: "128"


### PR DESCRIPTION
If auto replenished is enabled, stationary containers can be re-looted. When broken, usually by players, the loot is unpacked and the loottable is destroyed.

The commit expands the wording to also cover shulker boxes, which work a bit differently. In case a player breaks them, they are immediately looted and loose their replenishment ability. In case of a piston breaking them, they cannot unpack their loot table as no player exists in the context, so they only loose their loot table if they have been looted once before.