### PR TITLE
add maven dependency info

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,6 @@ indent_size = 2
 max_line_length = 100
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[{*.md,*.mdx}]
+indent_size = 4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,49 +106,49 @@ of a few ways:
 
 1. `SoftwareVersion` component
 
-   This component is used to embed the current version of the software into the documentation. An example of this would be:
+    This component is used to embed the current version of the software into the documentation. An example of this would be:
 
-   ```jsx
-   <SoftwareVersion versionType={"maj-min-pat"}/> // e.g. 1.19.2
-   <SoftwareVersion versionType={"maj-min"}/> // e.g. 1.19
-   <SoftwareVersion versionType={"maj"}/> // e.g. 1
+    ```jsx
+    <SoftwareVersion versionType={"maj-min-pat"}/> // e.g. 1.19.2
+    <SoftwareVersion versionType={"maj-min"}/> // e.g. 1.19
+    <SoftwareVersion versionType={"maj"}/> // e.g. 1
 
-   // You can set the project name to be used for the versioning (defaults to paper):
-   <SoftwareVersion versionType={"maj-min-pat"} project={"velocity"}/> // e.g. 3.3.0-SNAPSHOT
-   ```
+    // You can set the project name to be used for the versioning (defaults to paper):
+    <SoftwareVersion versionType={"maj-min-pat"} project={"velocity"}/> // e.g. 3.3.0-SNAPSHOT
+    ```
 
 2. `Javadoc` component
 
-   This component is used to embed a link to the current version of the corresponding Javadoc. An example of this would be:
+    This component is used to embed a link to the current version of the corresponding Javadoc. An example of this would be:
 
-   ```jsx
-   <Javadoc name={"org.bukkit.event.Event"}>here</Javadoc>
-   // The project can also be set here, and defaults to Paper
-   ```
+    ```jsx
+    <Javadoc name={"org.bukkit.event.Event"}>here</Javadoc>
+    // The project can also be set here, and defaults to Paper
+    ```
 
 3. `VersionFormattedCode` component
 
-   This component is used to embed a code block with the current version of the software. An example of this would be:
+    This component is used to embed a code block with the current version of the software. An example of this would be:
 
-   ````jsx
-   <VersionFormattedCode language={"yaml"}>
-   ```⠀
-   name: Paper-Test-Plugin
-   version: '1.0'
-   main: io.papermc.testplugin.TestPlugin
-   description: Paper Test Plugin
-   api-version: '%%_MAJ_MIN_PAT_MC_%%'
-   bootstrapper: io.papermc.testplugin.TestPluginBootstrap
-   loader: io.papermc.testplugin.TestPluginLoader
-   ```⠀
-   </VersionFormattedCode>
+    ````jsx
+    <VersionFormattedCode language={"yaml"}>
+    ```⠀
+    name: Paper-Test-Plugin
+    version: '1.0'
+    main: io.papermc.testplugin.TestPlugin
+    description: Paper Test Plugin
+    api-version: '%%_MAJ_MIN_PAT_MC_%%'
+    bootstrapper: io.papermc.testplugin.TestPluginBootstrap
+    loader: io.papermc.testplugin.TestPluginLoader
+    ```⠀
+    </VersionFormattedCode>
 
-   // The possible placeholders are:
-   %%_MAJ_MIN_MC_%%  - Major-Minor Paper Version (E.g. 1.20)
-   %%_MAJ_MIN_PAT_MC_%% - Major-Minor-Patch Paper Version (E.g. 1.20.4)
-   %%_MAJ_MIN_VEL_%% - Major Velocity Version (E.g. 3.1.0)
-   %%_MAJ_MIN_PAT_VEL_%% - Major-Minor-Patch Velocity Version (E.g. 3.1.1-SNAPSHOT)
-   ````
+    // The possible placeholders are:
+    %%_MAJ_MIN_MC_%%  - Major-Minor Paper Version (E.g. 1.20)
+    %%_MAJ_MIN_PAT_MC_%% - Major-Minor-Patch Paper Version (E.g. 1.20.4)
+    %%_MAJ_MIN_VEL_%% - Major Velocity Version (E.g. 3.1.0)
+    %%_MAJ_MIN_PAT_VEL_%% - Major-Minor-Patch Velocity Version (E.g. 3.1.1-SNAPSHOT)
+    ````
 
 When the major version of the software changes, the docs will still need to have a "snapshot" created to keep documentation
 for older versions. This is done by using Docusaurus's `version` command:

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ How to get docs running on your local machine for development.
 
 ### Prerequisites
 
-- [node](https://nodejs.org)
-- [pnpm](https://pnpm.io/installation)
+-   [node](https://nodejs.org)
+-   [pnpm](https://pnpm.io/installation)
 
 ### Local Development
 

--- a/docs/paper/dev/getting-started/project-setup.mdx
+++ b/docs/paper/dev/getting-started/project-setup.mdx
@@ -30,69 +30,65 @@ You will land into the `build.gradle.kts` file where you can add your dependenci
 To add Paper as a dependency, you will need to add the Paper repository to your `build.gradle.kts` or `pom.xml` file as well as the dependency itself.
 
 <Tabs groupId="author-front-matter">
+    <TabItem value="gradle-kotlin" label="Gradle Kotlin DSL" default>
+        <VersionFormattedCode language={"kotlin"} title={"build.gradle.kts"}>
+            ```
+            repositories {
+                maven {
+                    name = "papermc"
+                    url = uri("https://repo.papermc.io/repository/maven-public/")
+                }
+            }
 
-  <TabItem value="gradle-kotlin" label="Gradle Kotlin DSL" default>
+            dependencies {
+                compileOnly("io.papermc.paper:paper-api:%%_MAJ_MIN_PAT_MC_%%")
+            }
 
-    <VersionFormattedCode language={"kotlin"} title={"build.gradle.kts"}>
-      ```
-      repositories {
-        maven {
-          name = "papermc"
-          url = uri("https://repo.papermc.io/repository/maven-public/")
-        }
-      }
+            java {
+                toolchain.languageVersion.set(JavaLanguageVersion.of(21))
+            }
+            ```
+        </VersionFormattedCode>
+    </TabItem>
+    <TabItem value="gradle-groovy" label="Gradle Groovy DSL">
+        <VersionFormattedCode language={"groovy"} title={"build.gradle"}>
+            ```
+            repositories {
+                maven {
+                    name = 'papermc'
+                    url = 'https://repo.papermc.io/repository/maven-public/'
+                }
+            }
 
-      dependencies {
-        compileOnly("io.papermc.paper:paper-api:%%_MAJ_MIN_PAT_MC_%%")
-    }
-      ```
-    </VersionFormattedCode>
+            dependencies {
+                compileOnly 'io.papermc.paper:paper-api:%%_MAJ_MIN_PAT_MC_%%'
+            }
+            ```
+        </VersionFormattedCode>
+    </TabItem>
+    <TabItem value="maven" label="Maven POM">
+        <VersionFormattedCode language={"xml"} title={"pom.xml"}>
+        ```
+        <project>
+            <repositories>
+                <repository>
+                    <id>papermc</id>
+                    <url>https://repo.papermc.io/repository/maven-public/</url>
+                </repository>
+            </repositories>
 
-  </TabItem>
-  <TabItem value="gradle-groovy" label="Gradle Groovy DSL">
-
-    <VersionFormattedCode language={"groovy"} title={"build.gradle"}>
-      ```
-      repositories {
-        maven {
-          name = 'papermc'
-          url = 'https://repo.papermc.io/repository/maven-public/'
-        }
-      }
-
-      dependencies {
-        compileOnly 'io.papermc.paper:paper-api:%%_MAJ_MIN_PAT_MC_%%'
-      }
-      ```
-    </VersionFormattedCode>
-
-  </TabItem>
-
-  <TabItem value="maven" label="Maven POM">
-
-    <VersionFormattedCode language={"xml"} title={"pom.xml"}>
-      ```
-      <project>
-        <repositories>
-          <repository>
-            <id>papermc</id>
-            <url>https://repo.papermc.io/repository/maven-public/</url>
-          </repository>
-        </repositories>
-
-        <dependencies>
-          <dependency>
-            <groupId>io.papermc.paper</groupId>
-            <artifactId>paper-api</artifactId>
-            <version>%%_MAJ_MIN_PAT_MC_%%</version>
-            <scope>provided</scope>
-          </dependency>
-        </dependencies>
-      </project>
-      ```
-    </VersionFormattedCode>
-
-  </TabItem>
+            <dependencies>
+                <dependency>
+                    <groupId>io.papermc.paper</groupId>
+                    <artifactId>paper-api</artifactId>
+                    <version>%%_MAJ_MIN_PAT_MC_%%</version>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+        </project>
+        ```
+        </VersionFormattedCode>
+    </TabItem>
 </Tabs>
 
 ### Setting up the `src` directory

--- a/docs/paper/dev/getting-started/project-setup.mdx
+++ b/docs/paper/dev/getting-started/project-setup.mdx
@@ -27,24 +27,73 @@ You will land into the `build.gradle.kts` file where you can add your dependenci
 
 ### Adding Paper as a dependency
 
-To add Paper as a dependency, you will need to add the Paper repository to your `build.gradle.kts` file as well as the dependency itself.
+To add Paper as a dependency, you will need to add the Paper repository to your `build.gradle.kts` or `pom.xml` file as well as the dependency itself.
 
-<VersionFormattedCode language={"kotlin"} title={"build.gradle.kts"}>
-```
-repositories {
-    mavenCentral()
-    maven("https://repo.papermc.io/repository/maven-public/")
-}
+<Tabs groupId="author-front-matter">
 
-dependencies {
-    compileOnly("io.papermc.paper:paper-api:%%_MAJ_MIN_PAT_MC_%%-R0.1-SNAPSHOT")
-}
+  <TabItem value="gradle-kotlin" label="Gradle Kotlin DSL" default>
 
-java {
-    toolchain.languageVersion.set(JavaLanguageVersion.of(21))
-}
-```
-</VersionFormattedCode>
+    <VersionFormattedCode language={"kotlin"} title={"build.gradle.kts"}>
+      ```
+      repositories {
+        maven {
+          name = "papermc"
+          url = uri("https://repo.papermc.io/repository/maven-public/")
+        }
+      }
+
+      dependencies {
+        compileOnly("io.papermc.paper:paper-api:%%_MAJ_MIN_PAT_MC_%%")
+    }
+      ```
+    </VersionFormattedCode>
+
+  </TabItem>
+  <TabItem value="gradle-groovy" label="Gradle Groovy DSL">
+
+    <VersionFormattedCode language={"groovy"} title={"build.gradle"}>
+      ```
+      repositories {
+        maven {
+          name = 'papermc'
+          url = 'https://repo.papermc.io/repository/maven-public/'
+        }
+      }
+
+      dependencies {
+        compileOnly 'io.papermc.paper:paper-api:%%_MAJ_MIN_PAT_MC_%%'
+      }
+      ```
+    </VersionFormattedCode>
+
+  </TabItem>
+
+  <TabItem value="maven" label="Maven POM">
+
+    <VersionFormattedCode language={"xml"} title={"pom.xml"}>
+      ```
+      <project>
+        <repositories>
+          <repository>
+            <id>papermc</id>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
+          </repository>
+        </repositories>
+
+        <dependencies>
+          <dependency>
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-api</artifactId>
+            <version>%%_MAJ_MIN_PAT_MC_%%</version>
+            <scope>provided</scope>
+          </dependency>
+        </dependencies>
+      </project>
+      ```
+    </VersionFormattedCode>
+
+  </TabItem>
+</Tabs>
 
 ### Setting up the `src` directory
 

--- a/docs/paper/dev/getting-started/project-setup.mdx
+++ b/docs/paper/dev/getting-started/project-setup.mdx
@@ -41,7 +41,7 @@ To add Paper as a dependency, you will need to add the Paper repository to your 
             }
 
             dependencies {
-                compileOnly("io.papermc.paper:paper-api:%%_MAJ_MIN_PAT_MC_%%")
+                compileOnly("io.papermc.paper:paper-api:%%_MAJ_MIN_PAT_MC_%%-R0.1-SNAPSHOT")
             }
 
             java {
@@ -61,7 +61,7 @@ To add Paper as a dependency, you will need to add the Paper repository to your 
             }
 
             dependencies {
-                compileOnly 'io.papermc.paper:paper-api:%%_MAJ_MIN_PAT_MC_%%'
+                compileOnly 'io.papermc.paper:paper-api:%%_MAJ_MIN_PAT_MC_%%-R0.1-SNAPSHOT'
             }
             ```
         </VersionFormattedCode>
@@ -81,7 +81,7 @@ To add Paper as a dependency, you will need to add the Paper repository to your 
                 <dependency>
                     <groupId>io.papermc.paper</groupId>
                     <artifactId>paper-api</artifactId>
-                    <version>%%_MAJ_MIN_PAT_MC_%%</version>
+                    <version>%%_MAJ_MIN_PAT_MC_%%-R0.1-SNAPSHOT</version>
                     <scope>provided</scope>
                 </dependency>
             </dependencies>


### PR DESCRIPTION
Formatting needs to be double checked.

Currently the formatting in codeblocks is not consistent. On some pages it's 2 spaces and in other it's 4 spaces.