### PR TITLE
Fix inconsistency within publish.yml

### DIFF
--- a/docs/misc/hangar-publishing.md
+++ b/docs/misc/hangar-publishing.md
@@ -221,6 +221,6 @@ jobs:
       - name: Publish
         env:
           # Make sure you have added a repository secret in the repository's settings
-          HANGAR_TOKEN: ${{ secrets.HANGAR_API_TOKEN }}
+          HANGAR_API_TOKEN: ${{ secrets.HANGAR_API_TOKEN }}
         run: ./gradlew build publishPluginPublicationToHangar --stacktrace
 ```


### PR DESCRIPTION
When I tried to build this for myself I saw that `HANGAR_API_TOKEN` was instead called `HANGAR_TOKEN` this fixes that.