### PR TITLE
Fix typo for BukkitRunnable page

### DIFF
--- a/docs/paper/dev/api/scheduler.mdx
+++ b/docs/paper/dev/api/scheduler.mdx
@@ -209,7 +209,7 @@ public class CustomRunnable extends BukkitRunnable {
             return;
         }
 
-        task.cancel(); // The entity is no longer valid, there's no point in continuing to run this task
+        this.cancel(); // The entity is no longer valid, there's no point in continuing to run this task
     }
 }
 ```


### PR DESCRIPTION
Fixes a small typo in the `BukkitRunnable` section of the Scheduler page, where it uses `task.cancel();` when it actually should be `this.cancel();` as mentioned.