### PR TITLE
Bump minimum velocity version to 21

### DIFF
--- a/config-specs/properties.json
+++ b/config-specs/properties.json
@@ -1,5 +1,5 @@
 {
   "DOCS_JAVA": "21",
   "PAPER_JAVA_MIN": "21",
-  "VELOCITY_JAVA_MIN": "17"
+  "VELOCITY_JAVA_MIN": "21"
 }


### PR DESCRIPTION
Bump minimum velocity version to 21. It appears intentional that Velocity is ran with at least Java 21 since parts of the code base rely on specific Java 21 features. Such as commit https://github.com/PaperMC/Velocity/commit/ecf936f35665f9fd0f65ee114062cfbda2b89bf6.