### PR TITLE
[Quickfix] Remove beta versions as possible latest userdev version

### DIFF
--- a/src/util/versionUtils.ts
+++ b/src/util/versionUtils.ts
@@ -41,7 +41,10 @@ const createUserdevVersionsValue = (ttl: number = 5 * 60 * 1000): ExpiringValue<
       r.json()
     );
 
-    return json.map((e) => e.name.substring(1)).reverse();
+    return json
+      .map((e) => e.name.substring(1))
+      .filter((e) => !e.includes("beta"))
+      .reverse();
   });
 };
 


### PR DESCRIPTION
Just a very quick fix to jmp pushing out an experimental version of userdev, which should not be suggested as the latest version in the docs rn.

> [!NOTE]
> It would make sense to filter out pre-release versions on the GitHub api side of things, but as the current beta release is marked as a full release, that is sadly not possible for this exact case