### PR TITLE
[Quickfix] Add quick information about userdev 1.21.4 and beta versions

### DIFF
--- a/docs/paper/dev/getting-started/userdev.mdx
+++ b/docs/paper/dev/getting-started/userdev.mdx
@@ -54,8 +54,8 @@ Only the latest version of `paperweight-userdev` is officially supported, and we
 In order to use userdev for 1.21.4, you have to update your userdev to a beta version. At the time of writing, the latest version that works for
 1.21.4 is `2.0.0-beta.8`. You can find the latest version here: https://github.com/PaperMC/paperweight/releases.
 
-Furthermore, from version `2.0.0` onwards, userdev requires you to use at least **Gradle 8.11.2**. (Not 8.11!!). For more information on upgrading, check
-out this site from the gradle docs: https://docs.gradle.org/current/userguide/gradle_wrapper.html.
+Furthermore, from version `2.0.0` onwards, userdev requires you to use at least **Gradle 8.11.2** (Gradle 8.11 or below will not work). For more information on upgrading, check
+out this site from the Grade docs: https://docs.gradle.org/current/userguide/gradle_wrapper.html.
 
 :::
 

--- a/docs/paper/dev/getting-started/userdev.mdx
+++ b/docs/paper/dev/getting-started/userdev.mdx
@@ -49,6 +49,16 @@ plugins {
 The latest version of `paperweight-userdev` supports dev bundles for Minecraft 1.17.1 and newer, so it's best practice to keep it up to date!
 Only the latest version of `paperweight-userdev` is officially supported, and we will ask you to update first if you are having problems with old versions.
 
+:::warning
+
+In order to use userdev for 1.21.4, you have to update your userdev to a beta version. At the time of writing, the latest version that works for
+1.21.4 is `2.0.0-beta.8`. You can find the latest version here: https://github.com/PaperMC/paperweight/releases.
+
+Furthermore, from version `2.0.0` onwards, userdev requires you to use at least **Gradle 8.11.2**. (Not 8.11!!). For more information on upgrading, check
+out this site from the gradle docs: https://docs.gradle.org/current/userguide/gradle_wrapper.html.
+
+:::
+
 :::info[Snapshots]
 
 **paperweight-userdev** SNAPSHOT (pre-release) versions are only available through Paper's Maven repository.

--- a/docs/paper/dev/getting-started/userdev.mdx
+++ b/docs/paper/dev/getting-started/userdev.mdx
@@ -55,7 +55,7 @@ In order to use userdev for 1.21.4, you have to update your userdev to a beta ve
 1.21.4 is `2.0.0-beta.8`. You can find the latest version here: https://github.com/PaperMC/paperweight/releases.
 
 Furthermore, from version `2.0.0` onwards, userdev requires you to use at least **Gradle 8.11.2** (Gradle 8.11 or below will not work). For more information on upgrading, check
-out this site from the Grade docs: https://docs.gradle.org/current/userguide/gradle_wrapper.html.
+out this site from the Gradle docs: https://docs.gradle.org/current/userguide/gradle_wrapper.html.
 
 :::
 


### PR DESCRIPTION
Regarding the lot of recent questions about userdev on **1.21.4**, this PR adds a warning so make people aware of the need for gradle 8.11.2 and the beta userdev releases.