### PR TITLE
fix: Update paperweight-userdev Gradle plugin reference

### DIFF
--- a/docs/paper/dev/getting-started/userdev.mdx
+++ b/docs/paper/dev/getting-started/userdev.mdx
@@ -48,16 +48,9 @@ plugins {
 
 The latest version of `paperweight-userdev` supports dev bundles for Minecraft 1.17.1 and newer, so it's best practice to keep it up to date!
 Only the latest version of `paperweight-userdev` is officially supported, and we will ask you to update first if you are having problems with old versions.
-
-:::warning
-
-In order to use userdev for 1.21.4, you have to update your userdev to a beta version. At the time of writing, the latest version that works for
-1.21.4 is `2.0.0-beta.8`. You can find the latest version here: https://github.com/PaperMC/paperweight/releases.
-
-Furthermore, from version `2.0.0` onwards, userdev requires you to use at least **Gradle 8.11.2** (Gradle 8.11 or below will not work). For more information on upgrading, check
-out this site from the Gradle docs: https://docs.gradle.org/current/userguide/gradle_wrapper.html.
-
-:::
+Furthermore, if you are having issues with `paperweight-userdev`, it is suggested that you update your Gradle version to the latest version. For more information on upgrading Gradle,
+check out [the Gradle wrapper documentation](https://docs.gradle.org/current/userguide/gradle_wrapper.html). If you keep experiencing issues, you should ask in the 
+[`#build-tooling-help`](https://discord.com/channels/289587909051416579/1078993196924813372) channel in our dedicated [Discord server](https://discord.gg/PaperMC)!
 
 :::info[Snapshots]
 

--- a/src/util/versionUtils.ts
+++ b/src/util/versionUtils.ts
@@ -41,10 +41,7 @@ const createUserdevVersionsValue = (ttl: number = 5 * 60 * 1000): ExpiringValue<
       r.json()
     );
 
-    return json
-      .map((e) => e.name.substring(1))
-      .filter((e) => !e.includes("beta"))
-      .reverse();
+    return json.map((e) => e.name.substring(1)).reverse();
   });
 };
 


### PR DESCRIPTION
This PR removes the filtering out of beta versions from the latest-version fetch in order to display the now pretty much stable beta builds, as they are required for 1.21.4 support and provide fixes for older versions as well.

Furthermore, I have added a reference to the Gradle wrapper page for updating your Gradle distribution and added a reference to the #build-tooling-help channel from our Discord server for people seeking further support.