### PR TITLE
Update plugin-messaging.mdx

### DIFF
--- a/docs/paper/dev/api/plugin-messaging.mdx
+++ b/docs/paper/dev/api/plugin-messaging.mdx
@@ -92,15 +92,16 @@ These are the following:
 |:------------------|:-------------------------------------------------------|:-----------------------------------------------------------------|:--------------------------------------------------|
 | `Connect`         | Connects the player to the specified server.           | `server name`                                                    | N/A                                               |
 | `ConnectOther`    | Connects another player to the specified server.       | `player name`, `server name`                                     | N/A                                               |
-| `IP`              | Returns the IP of the specified player.                | `player name`                                                    | `IP`, `port`                                      |
+| `IP`              | Returns the IP of the player.                          | N/A                                                              | `IP`, `port`                                      |
+| `IPOther`         | Returns the IP of the specified player.                | `player name`                                                    | `player name`, `IP`, `port`                       |
 | `PlayerCount`     | Returns the number of players on the specified server. | `server name`                                                    | `server name`, `player count`                     |
 | `PlayerList`      | Returns a list of players on the specified server.     | `server name`                                                    | `server name`, `CSV player names`                 |
 | `GetServers`      | Returns a list of all servers.                         | N/A                                                              | `CSV server names`                                |
 | `Message`         | Sends a message to the specified player.               | `player name`, `message`                                         | N/A                                               |
 | `MessageRaw`      | Sends a raw chat component to the specified player.    | `player name`, `JSON chat component`                             | N/A                                               |
 | `GetServer`       | Returns the server the player is connected to.         | N/A                                                              | `server name`                                     |
-| `GetPlayerServer` | Returns the server name of the specified player.       | `player name`                                                    | `player name`, `server name`                       |
-| `UUID`            | Returns the UUID of player.                            | N/A                                                              | `UUID`                                            |
+| `GetPlayerServer` | Returns the server name of the specified player.       | `player name`                                                    | `player name`, `server name`                      |
+| `UUID`            | Returns the UUID of the player.                        | N/A                                                              | `UUID`                                            |
 | `UUIDOther`       | Returns the UUID of the specified player.              | `player name`                                                    | `player name`, `UUID`                             |
 | `ServerIp`        | Returns the IP of the specified server.                | `server name`                                                    | `server name`, `IP`, `port`                       |
 | `KickPlayer`      | Kicks the specified player.                            | `player name`, `reason`                                          | N/A                                               |


### PR DESCRIPTION
- Added `IPOther` ([existed](https://github.com/PaperMC/Velocity/blob/dev/3.0.0/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/BungeeCordMessageResponder.java#L391) but not documented)
- Fixed `IP` originally used the description of `IPOther`.
- Added missing `the` for `UUID`.