### PR TITLE
Updated chmod permission

### DIFF
--- a/docs/velocity/admin/getting-started/README.mdx
+++ b/docs/velocity/admin/getting-started/README.mdx
@@ -59,7 +59,7 @@ java -Xms1G -Xmx1G -XX:+UseG1GC -XX:G1HeapRegionSize=4M -XX:+UnlockExperimentalV
 
 Once saved, open a terminal (or log into the machine) if you haven't already, navigate to the
 directory where you have placed the Velocity JAR file and the `start.sh` file. Then run
-`chmod +x start.sh` and then `./start.sh`. If it worked, you should now receive a console similar to
+`chmod u+x start.sh` and then `./start.sh`. If it worked, you should now receive a console similar to
 the output in the next section.
 
 ## After launch


### PR DESCRIPTION
Within Linux's chmod system, `+x` grants all users access to execute the file, whereas `u+x` only grants the user who owns the file access to execute it. Provided the user is the one who created the `start.sh` file, there's no reason why this permission change wouldn't cause issues, but it's good to get into the habit of using "least privilege" when assigning permissions, and I know from personal experience that hosting Minecraft servers can be the start of a career in sysadmining.