### PR TITLE
Explain paper-world-defaults.yml's tick-rate.container-update option better.

### DIFF
--- a/config-specs/paper/paper-world-defaults.yml
+++ b/config-specs/paper/paper-world-defaults.yml
@@ -1002,8 +1002,8 @@ tick-rates:
     description: >-
       The rate, in ticks, at which the server updates containers and inventories.
       Higher values than 1 can cause item desync/ghosting or make block breaking
-      progress appear to reset randomly. This can make the server appear laggy 
-      to clients, even at 20 TPS and low ping.
+      progress appear to reset randomly. It can also create visual artefacts mimicking
+      server lag to clients, despite this not being the case.
   grass-spread:
     default: "1"
     description: >-

--- a/config-specs/paper/paper-world-defaults.yml
+++ b/config-specs/paper/paper-world-defaults.yml
@@ -1002,7 +1002,7 @@ tick-rates:
     description: >-
       The rate, in ticks, at which the server updates containers and inventories.
       Higher values than 1 can cause item desync/ghosting or make block breaking
-      progress appear to reset randomly. It can also create visual artefacts mimicking
+      progress appear to reset randomly. It can also create visual artifacts mimicking
       server lag to clients, despite this not being the case.
   grass-spread:
     default: "1"

--- a/config-specs/paper/paper-world-defaults.yml
+++ b/config-specs/paper/paper-world-defaults.yml
@@ -999,7 +999,11 @@ tick-rates:
           for the names. Might change between updates!
   container-update:
     default: "1"
-    description: "The rate, in ticks, at which the server updates containers and inventories"
+    description: >-
+      The rate, in ticks, at which the server updates containers and inventories.
+      Higher values than 1 can cause item desync/ghosting or make block breaking
+      progress appear to reset randomly. This can make the server appear laggy 
+      to clients, even at 20 TPS and low ping.
   grass-spread:
     default: "1"
     description: >-


### PR DESCRIPTION
This config option has some nasty consequences for survival and should be explained. I had some very weird problems after tuning this option (trying to save a server with ~500 players online from 1 TPS) and it was difficult to understand what was going on without a lot of trial and error. 

This clarification is based on my experience in #folia-help and should make it easier for server admins in the future to avoid degrading player experience unintentionally.