### PR TITLE
Fixed Aikar's flags in "Start Script Generator"

### DIFF
--- a/src/components/StartScriptGenerator.tsx
+++ b/src/components/StartScriptGenerator.tsx
@@ -32,7 +32,6 @@ const FLAGS: Option[] = [
       "-XX:G1MixedGCCountTarget=4",
       "-XX:G1MixedGCLiveThresholdPercent=90",
       "-XX:G1RSetUpdatingPauseTimePercent=5",
-      "-XX:InitiatingHeapOccupancyPercent=15",
       "-XX:MaxGCPauseMillis=200",
       "-XX:MaxTenuringThreshold=1",
       "-XX:SurvivorRatio=32",
@@ -44,13 +43,15 @@ const FLAGS: Option[] = [
         "-XX:G1NewSizePercent=30",
         "-XX:G1MaxNewSizePercent=40",
         "-XX:G1HeapRegionSize=8M",
-        "-XX:G1ReservePercent=20"
+        "-XX:G1ReservePercent=20",
+        "-XX:InitiatingHeapOccupancyPercent=15"
         ].join(" ")],
       [12, [
         "-XX:G1NewSizePercent=40",
         "-XX:G1MaxNewSizePercent=50",
         "-XX:G1HeapRegionSize=16M",
-        "-XX:G1ReservePercent=15"
+        "-XX:G1ReservePercent=15",
+        "-XX:InitiatingHeapOccupancyPercent=20"
         ].join(" ")]
       ]),
     description: "Optimized Minecraft flags by Aikar for better server performance.",

--- a/src/components/StartScriptGenerator.tsx
+++ b/src/components/StartScriptGenerator.tsx
@@ -38,7 +38,7 @@ const FLAGS: Option[] = [
       "-Dusing.aikars.flags=https://mcflags.emc.gs",
       "-Daikars.new.flags=true",
     ].join(" "),
-    altValue: new Map<number, string>([ // Alternate values for different memory sizes. The outputted flags will match the closest lower bound.
+    altFlags: new Map<number, string>([ // Alternate values for different memory sizes. The outputted flags will match the closest lower bound.
       [0, [                             // Example: If the memory is 12 or 13.5, the flags for 12 will be used, and if the memory is 4 or 11.5, the flags for 0 will be used.
         "-XX:G1NewSizePercent=30",
         "-XX:G1MaxNewSizePercent=40",
@@ -81,19 +81,19 @@ const VELOCITY = FLAGS[2];
 const isServerSide = typeof document === "undefined";
 
 
-// Works with the altValue property of the Option object defined in Select.tsx.
+// Works with the altFlags property of the Option object defined in Select.tsx.
 // Returns the flags for the closest lower bound of memory. Necessary for Aikar's flags that change depending on memory size.
 // Takes in memory and selectedFlag as arguments. Returns a string of flags.
-// Returns "" if the selectedFlag does not have an altValue property.
+// Returns "" if the selectedFlag does not have an altFlags property.
 function getAltFlags(memory: number, selectedFlag: Option): string {
-  if (!selectedFlag.altValue) return "";
+  if (!selectedFlag.altFlags) return "";
   let closestKey = 0;
-  for (const currentKey of selectedFlag.altValue.keys()) {
+  for (const currentKey of selectedFlag.altFlags.keys()) {
       if (memory >= currentKey && currentKey > closestKey) {
           closestKey = currentKey;
       }
   }
-  return selectedFlag.altValue.get(closestKey);
+  return selectedFlag.altFlags.get(closestKey);
 }
 
 const generateStartCommand = (

--- a/src/components/StartScriptGenerator.tsx
+++ b/src/components/StartScriptGenerator.tsx
@@ -38,22 +38,30 @@ const FLAGS: Option[] = [
       "-Dusing.aikars.flags=https://mcflags.emc.gs",
       "-Daikars.new.flags=true",
     ].join(" "),
-    altFlags: new Map<number, string>([ // Alternate values for different memory sizes. The outputted flags will match the closest lower bound.
-      [0, [                             // Example: If the memory is 12 or 13.5, the flags for 12 will be used, and if the memory is 4 or 11.5, the flags for 0 will be used.
-        "-XX:G1NewSizePercent=30",
-        "-XX:G1MaxNewSizePercent=40",
-        "-XX:G1HeapRegionSize=8M",
-        "-XX:G1ReservePercent=20",
-        "-XX:InitiatingHeapOccupancyPercent=15"
-        ].join(" ")],
-      [12, [
-        "-XX:G1NewSizePercent=40",
-        "-XX:G1MaxNewSizePercent=50",
-        "-XX:G1HeapRegionSize=16M",
-        "-XX:G1ReservePercent=15",
-        "-XX:InitiatingHeapOccupancyPercent=20"
-        ].join(" ")]
-      ]),
+    altFlags: new Map<number, string>([
+      // Alternate values for different memory sizes. The outputted flags will match the closest lower bound.
+      // Example: If the memory is 12 or 13.5, the flags for 12 will be used, and if the memory is 4 or 11.5, the flags for 0 will be used.
+      [
+        0,
+        [
+          "-XX:G1NewSizePercent=30",
+          "-XX:G1MaxNewSizePercent=40",
+          "-XX:G1HeapRegionSize=8M",
+          "-XX:G1ReservePercent=20",
+          "-XX:InitiatingHeapOccupancyPercent=15",
+        ].join(" "),
+      ],
+      [
+        12,
+        [
+          "-XX:G1NewSizePercent=40",
+          "-XX:G1MaxNewSizePercent=50",
+          "-XX:G1HeapRegionSize=16M",
+          "-XX:G1ReservePercent=15",
+          "-XX:InitiatingHeapOccupancyPercent=20",
+        ].join(" "),
+      ],
+    ]),
     description: "Optimized Minecraft flags by Aikar for better server performance.",
   },
   {
@@ -80,7 +88,6 @@ const VELOCITY = FLAGS[2];
 
 const isServerSide = typeof document === "undefined";
 
-
 // Works with the altFlags property of the Option object defined in Select.tsx.
 // Returns the flags for the closest lower bound of memory. Necessary for Aikar's flags that change depending on memory size.
 // Takes in memory and selectedFlag as arguments. Returns a string of flags.
@@ -89,9 +96,9 @@ function getAltFlags(memory: number, selectedFlag: Option): string {
   if (!selectedFlag.altFlags) return "";
   let closestKey = 0;
   for (const currentKey of selectedFlag.altFlags.keys()) {
-      if (memory >= currentKey && currentKey > closestKey) {
-          closestKey = currentKey;
-      }
+    if (memory >= currentKey && currentKey > closestKey) {
+      closestKey = currentKey;
+    }
   }
   return selectedFlag.altFlags.get(closestKey);
 }

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -164,5 +164,6 @@ interface SelectProps {
 export interface Option {
   label: string;
   value: string;
+  alt_value?: Map<number, string>;
   description?: string;
 }

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -164,6 +164,5 @@ interface SelectProps {
 export interface Option {
   label: string;
   value: string;
-  alt_value?: Map<number, string>;
   description?: string;
 }


### PR DESCRIPTION
Some of the flags in Aikar's Flags change slightly depending on how much RAM you're allocating to the server. [(Source)](https://aikar.co/category/minecraft/#:~:text=If%20you%20are%20using%20an%20Xmx%20value%20greater%20than%2012G)

The "[Start Script Generator](https://docs.papermc.io/misc/tools/start-script-gen)" on PaperMC's docs does not currently reflect this.

I have made changes to `StartScriptGenerator.tsx` to properly output Aikar's flags depending on the RAM.

The changes were:
- Added `altFlags` to the `FLAGS` `Option[]` in `StartScriptGenerator.tsx` to define flags that change depending on `memory`.
- Creation of the `getAltFlags(memory, selectedFlag)` function in`StartScriptGenerator.tsx`, which returns a string of the correct flags according to the provided `memory` and `selectedFlag`. Returns "" if `altFlags` is not present.
- Called `${getAltFlags(memory, selectedFlag)}` in the `const command = "..."` part of `StartScriptGenerator.tsx`

I originally also changed `Option` interface defined in `Select.tsx`, but then I realised my changes in `StartScriptGenerator.tsx` worked regardless of if I added the line `altValue?: Map<number, string>;` to the defined Option interface, so I kept it as it was. Feel free to tell me if I implemented this part wrong.

I tried to make this as non-spaghetti code as possible. The memory boundaries for `altFlags` are easily adjustable and you can easily add new `altFlags` entries for other sets of flags should it ever be necessary.

## Modified "Start Script Generator" working:
![unknown](https://github.com/user-attachments/assets/4d95cfdd-a26a-4bf7-9600-9cbd65f1de7b)
![unknown](https://github.com/user-attachments/assets/20acd30c-54f5-4583-a5d0-0f069bd86bc6)


