### PR TITLE
paper-global.yml - add bypass for vanilla ride command player restriction

### DIFF
--- a/config-specs/paper/paper-global.yml
+++ b/config-specs/paper/paper-global.yml
@@ -143,7 +143,7 @@ commands:
     description: >-
       Whether the /time command should act on all worlds or just the sender's
       current world
-  rideCommandAllowPlayerAsVehicle:
+  ride-command-allow-player-as-vehicle:
     default: "false"
     description: >-
       Allow mounting entities to a player in the vanilla '/ride' command.

--- a/config-specs/paper/paper-global.yml
+++ b/config-specs/paper/paper-global.yml
@@ -143,6 +143,10 @@ commands:
     description: >-
       Whether the /time command should act on all worlds or just the sender's
       current world
+  rideCommandAllowPlayerAsVehicle:
+    default: "false"
+    description: >-
+      Allow mounting entities to a player in the vanilla '/ride' command.
 console:
   enable-brigadier-completions:
     default: "true"
@@ -515,8 +519,8 @@ unsupported-settings:
     vanilla: "false"
     default: "true"
     description: >-
-      This setting controls if equipment should be updated when handling certain player 
-      actions. If set to false this will allow players to exploit attributes by e.g. 
+      This setting controls if equipment should be updated when handling certain player
+      actions. If set to false this will allow players to exploit attributes by e.g.
       switching equipment before using it.
 watchdog:
   early-warning-delay:

--- a/config-specs/paper/paper-global.yml
+++ b/config-specs/paper/paper-global.yml
@@ -145,8 +145,7 @@ commands:
       current world
   ride-command-allow-player-as-vehicle:
     default: "false"
-    description: >-
-      Allow mounting entities to a player in the Vanilla `/ride` command.
+    description: Allow mounting entities to a player in the Vanilla `/ride` command.
 console:
   enable-brigadier-completions:
     default: "true"

--- a/config-specs/paper/paper-global.yml
+++ b/config-specs/paper/paper-global.yml
@@ -146,7 +146,7 @@ commands:
   ride-command-allow-player-as-vehicle:
     default: "false"
     description: >-
-      Allow mounting entities to a player in the vanilla '/ride' command.
+      Allow mounting entities to a player in the Vanilla `/ride` command.
 console:
   enable-brigadier-completions:
     default: "true"


### PR DESCRIPTION
This PR aims to add docs for a config option:
https://github.com/PaperMC/Paper/pull/12327

(I did not touch that "unsupported setting" at the bottom there, I guess IntelliJ wanted to take control)