### PR TITLE
feat: move userdev advise for gradle version to note block

### DIFF
--- a/docs/paper/dev/getting-started/userdev.mdx
+++ b/docs/paper/dev/getting-started/userdev.mdx
@@ -55,7 +55,7 @@ For more information on upgrading Gradle, check out the [Gradle Wrapper document
 
 The latest version of `paperweight-userdev` supports dev bundles for Minecraft 1.17.1 and newer, so it's best practice to keep it up to date!
 Only the latest version of `paperweight-userdev` is officially supported, and we will ask you to update first if you are having problems with old versions.
-Furthermore, if you are having issues with `paperweight-userdev` you should ask in the
+Furthermore, if you are having issues with `paperweight-userdev`, you should ask in the
 [`#build-tooling-help`](https://discord.com/channels/289587909051416579/1078993196924813372) channel in our dedicated [Discord server](https://discord.gg/PaperMC)!
 
 :::info[Snapshots]

--- a/docs/paper/dev/getting-started/userdev.mdx
+++ b/docs/paper/dev/getting-started/userdev.mdx
@@ -49,7 +49,7 @@ plugins {
 :::note[Gradle Version]
 
 Please make sure you are using the latest stable version of Gradle.
-For more information on upgrading Gradle, check out [the Gradle wrapper documentation](https://docs.gradle.org/current/userguide/gradle_wrapper.html).
+For more information on upgrading Gradle, check out the [Gradle Wrapper documentation](https://docs.gradle.org/current/userguide/gradle_wrapper.html).
 
 :::
 

--- a/docs/paper/dev/getting-started/userdev.mdx
+++ b/docs/paper/dev/getting-started/userdev.mdx
@@ -46,10 +46,16 @@ plugins {
 ```
 </VersionFormattedCode>
 
+:::note[Gradle Version]
+
+Please make sure you are using the latest stable version of Gradle.
+For more information on upgrading Gradle, check out [the Gradle wrapper documentation](https://docs.gradle.org/current/userguide/gradle_wrapper.html).
+
+:::
+
 The latest version of `paperweight-userdev` supports dev bundles for Minecraft 1.17.1 and newer, so it's best practice to keep it up to date!
 Only the latest version of `paperweight-userdev` is officially supported, and we will ask you to update first if you are having problems with old versions.
-Furthermore, if you are having issues with `paperweight-userdev`, it is suggested that you update your Gradle version to the latest version. For more information on upgrading Gradle,
-check out [the Gradle wrapper documentation](https://docs.gradle.org/current/userguide/gradle_wrapper.html). If you keep experiencing issues, you should ask in the 
+Furthermore, if you are having issues with `paperweight-userdev` you should ask in the
 [`#build-tooling-help`](https://discord.com/channels/289587909051416579/1078993196924813372) channel in our dedicated [Discord server](https://discord.gg/PaperMC)!
 
 :::info[Snapshots]


### PR DESCRIPTION
Close https://github.com/PaperMC/docs/issues/556 moving the mention of the gradle version to a block note for make more clear about the need of keep gradle updated.