### PR TITLE
Make Gradle update-version block more visible

### DIFF
--- a/docs/paper/dev/getting-started/userdev.mdx
+++ b/docs/paper/dev/getting-started/userdev.mdx
@@ -48,9 +48,14 @@ plugins {
 
 The latest version of `paperweight-userdev` supports dev bundles for Minecraft 1.17.1 and newer, so it's best practice to keep it up to date!
 Only the latest version of `paperweight-userdev` is officially supported, and we will ask you to update first if you are having problems with old versions.
-Furthermore, if you are having issues with `paperweight-userdev`, it is suggested that you update your Gradle version to the latest version. For more information on upgrading Gradle,
-check out [the Gradle wrapper documentation](https://docs.gradle.org/current/userguide/gradle_wrapper.html). If you keep experiencing issues, you should ask in the 
+
+:::warning[Common Issues]
+
+If you are having issues with `paperweight-userdev`, you should update your **Gradle version** to the latest version. For information on upgrading Gradle,
+check out [the Gradle wrapper documentation](https://docs.gradle.org/current/userguide/gradle_wrapper.html). If you keep experiencing issues, you can ask in the
 [`#build-tooling-help`](https://discord.com/channels/289587909051416579/1078993196924813372) channel in our dedicated [Discord server](https://discord.gg/PaperMC)!
+
+:::
 
 :::info[Snapshots]
 


### PR DESCRIPTION
Fixes #556 