### PR TITLE
feat: Add last modified by

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -38,6 +38,7 @@ export default defineConfig({
         Sidebar: "./src/components/overrides/Sidebar.astro",
         PageFrame: "./src/components/overrides/PageFrame.astro",
         Footer: "./src/components/overrides/Footer.astro",
+        LastUpdated: "./src/components/overrides/LastUpdated.astro",
         Banner: "./src/components/overrides/Banner.astro",
         TableOfContents: "./src/components/overrides/TableOfContents.astro",
         MobileTableOfContents: "./src/components/overrides/MobileTableOfContents.astro",

--- a/src/components/overrides/LastUpdated.astro
+++ b/src/components/overrides/LastUpdated.astro
@@ -1,0 +1,24 @@
+---
+import { type GitHubAccount, getGitHubAccountFromFile } from "/src/utils/git-utils.ts"
+
+const { lang, lastUpdated } = Astro.locals.starlightRoute;
+const filePath = Astro.locals.starlightRoute.entry.filePath
+
+const acc: GitHubAccount = await getGitHubAccountFromFile(filePath);
+---
+
+{
+  lastUpdated && (
+    <p>
+      {"Last updated: "}
+      <time datetime={lastUpdated.toISOString()}>
+        {lastUpdated.toLocaleDateString(lang, {
+          dateStyle: "medium",
+          timeZone: "UTC",
+        })}
+      </time>
+      {" by "}
+      <a set:html={acc.displayName} href={acc.accountLink} />
+    </p>
+  )
+}

--- a/src/content/docs/paper/dev/api/command-api/basics/introduction.md
+++ b/src/content/docs/paper/dev/api/command-api/basics/introduction.md
@@ -48,4 +48,4 @@ The following pages will be added to the documentation in the future:
 :::
 
 ## Additional support
-For support regarding the command API, you can always ask in our [Discord Server](https://discord.gg/PaperMC) in the `#paper-dev` channel!
+For support regarding the command API, you can always ask in our Discord server under the [`#paper-dev`](https://discord.com/channels/289587909051416579/555462289851940864) channel!

--- a/src/utils/git-utils.ts
+++ b/src/utils/git-utils.ts
@@ -1,0 +1,79 @@
+import { execSync } from "child_process";
+
+export interface GitHubAccount {
+  displayName: string;
+  email: string;
+  accountLink?: string;
+}
+
+const headers = {
+  headers: {
+    Accept: "application/vnd.github+json",
+    "User-Agent": "papermc-docs/author",
+  },
+};
+
+const repo: string = "PaperMC/docs"
+const cache: Map<string, GitHubAccount> = new Map();
+
+// Git
+export async function getGitHubAccountFromFile(
+  filePath: string
+): Promise<GitHubAccount | null> {
+  const displayName = execSync(
+    `git log -1 --pretty="format:%an" -- "${filePath}"`
+  ).toString();
+  const email = execSync(
+    `git log -1 --pretty="format:%ae" -- "${filePath}"`
+  ).toString();
+
+  const cached = cache.get(email);
+  if (cached != null) {
+    cached.displayName = displayName;
+    return cached;
+  }
+
+  const accLink = await getGitHubAccountLinkByEmail(email);
+  if (accLink != null) {
+    const acc: GitHubAccount = {
+      displayName: displayName,
+      email: email,
+      accountLink: accLink,
+    };
+    cache.set(email, acc);
+    return acc;
+  }
+
+  // As the email seems to not be directly linked to an account, we instead use the GitHub API
+  const url = new URL(`https://api.github.com/repos/${repo}/commits`);
+  url.searchParams.set('path', filePath);
+  url.searchParams.set('per_page', '1');
+
+  const commit = (await fetch(url, headers).then(response => response.json()))[0]
+  const acc: GitHubAccount = {
+    displayName: displayName,
+    email: email,
+    accountLink: commit?.author?.html_url
+  }
+
+  console.log("Latest commit data is as follows:")
+  console.log(commit)
+  cache.set(email, acc);
+  return acc;
+}
+
+// E-Mail related
+
+export async function getGitHubAccountLinkByEmail(
+  email: string
+): Promise<string | null> {
+  const url = new URL(`https://api.github.com/search/users?q=${email}`);
+  const result = await fetch(url, headers).then((response) => response.json());
+
+  if (result?.items == null || result.items.length < 1) {
+    return null;
+  }
+
+  const item = result.items[0];
+  return item.html_url;
+}

--- a/src/utils/git-utils.ts
+++ b/src/utils/git-utils.ts
@@ -49,15 +49,15 @@ export async function getGitHubAccountFromFile(
   url.searchParams.set('path', filePath);
   url.searchParams.set('per_page', '1');
 
+  // It is **KNOWN** that if a commit is not pushed to GitHub, the link will be of the person who last edited the page remotely.
+  // This is only a bug in local dev or other branch environments, and not in production.
   const commit = (await fetch(url, headers).then(response => response.json()))[0]
-  const acc: GitHubAccount = {
+  let acc: GitHubAccount = {
     displayName: displayName,
     email: email,
     accountLink: commit?.author?.html_url
   }
 
-  console.log("Latest commit data is as follows:")
-  console.log(commit)
   cache.set(email, acc);
   return acc;
 }


### PR DESCRIPTION
This re-adds the previous behavior where it also displays the person who last edited a certain page. For obvious reasons, this mostly displays only @zlataovce. But I have also verified that on the pages `/paper/basic-troubleshooting/` and `/paper/reference/bukkit-help-configuration/`, which have been modified since the starlight rewrite, the correct PR author is noted down.

There is a known bug where it shows the correct name for local/branched commits, but shows an incorrect link. This does not impact production builds though. The account link is, if the email cannot be traced back to an account directly, retrieved from the latest commit on a file from the main branch of the repository, which may be outdated.