### PR TITLE
typo: "runs the merge later logic into y."

### DIFF
--- a/src/content/docs/folia/admin/reference/region-logic.md
+++ b/src/content/docs/folia/admin/reference/region-logic.md
@@ -224,8 +224,8 @@ created is added to the set x, as it is the section that is known
 to not be ticking - this is done to adhere to invariant third invariant.
 
 Every region y in the set X that is not x is merged into x if
-y is not in the ticking state, otherwise x runs the merge later
-logic into y.
+y is not in the ticking state, otherwise x runs the merge
+logic into y later.
 
 ### Merge later logic
 


### PR DESCRIPTION
runs the merge logic into y later.