### PR TITLE
chore: use node 22 and github actions improvements

### DIFF
--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -8,5 +8,5 @@ runs:
     - name: "setup node"
       uses: "actions/setup-node@v4"
       with:
-      cache: "pnpm"
-      node-version: 22
+        cache: "pnpm"
+        node-version: 22

--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -1,0 +1,12 @@
+name: setup-node-pnpm
+description: Setup Node and PNPM
+runs:
+  using: "composite"
+  steps:
+    - name: "setup pnpm"
+      uses: "pnpm/action-setup@v4"
+    - name: "setup node"
+      uses: "actions/setup-node@v4"
+      with:
+      cache: "pnpm"
+      node-version: 22

--- a/.github/workflows/build-preview.yaml
+++ b/.github/workflows/build-preview.yaml
@@ -15,13 +15,8 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: "setup pnpm"
-        uses: "pnpm/action-setup@v4"
-      - name: "setup node"
-        uses: "actions/setup-node@v4"
-        with:
-          cache: "pnpm"
-          node-version: 20
+      - name: "setup node and pnpm"
+        uses: ./.github/actions/setup-node-pnpm
       - name: "setup d2"
         run: "curl -fsSL https://d2lang.com/install.sh | sh -s --"
       - name: "install dependencies"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -17,13 +17,8 @@ jobs:
         uses: "actions/checkout@v4"
         with:
           fetch-depth: 0
-      - name: "setup pnpm"
-        uses: "pnpm/action-setup@v4"
-      - name: "setup node"
-        uses: "actions/setup-node@v4"
-        with:
-          cache: "pnpm"
-          node-version: 20
+      - name: "setup node and pnpm"
+        uses: ./.github/actions/setup-node-pnpm
       - name: "setup d2"
         run: "curl -fsSL https://d2lang.com/install.sh | sh -s --"
       - name: "install dependencies"

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -13,13 +13,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-      - name: Set up Node
-        uses: actions/setup-node@v4
-        with:
-          cache: "pnpm"
-          node-version: 20
+      - name: "setup node and pnpm"
+        uses: ./.github/actions/setup-node-pnpm
       - name: Install dependencies
         run: pnpm install
       - name: Check format

--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -14,4 +14,4 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Spell check
-        uses: crate-ci/typos@v1.24.6
+        uses: crate-ci/typos@v1

--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -14,4 +14,4 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Spell check
-        uses: crate-ci/typos@v1
+        uses: crate-ci/typos@v1.32.0

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ How to get docs running on your local machine for development.
 
 ### Prerequisites
 
-- [node](https://nodejs.org)
+- [node 22](https://nodejs.org)
 - [pnpm](https://pnpm.io/installation)
 - [d2](https://d2lang.com/) (optional for development - used for generating diagrams)
 

--- a/package.json
+++ b/package.json
@@ -37,5 +37,8 @@
     "prettier-plugin-organize-imports": "^4.1.0",
     "prettier-plugin-svelte": "^3.3.3"
   },
+  "engines" : {
+    "node": "22.x"
+  },
   "packageManager": "pnpm@10.8.0+sha512.0e82714d1b5b43c74610193cb20734897c1d00de89d0e18420aebc5977fa13d780a9cb05734624e81ebd81cc876cd464794850641c48b9544326b5622ca29971"
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "prettier-plugin-organize-imports": "^4.1.0",
     "prettier-plugin-svelte": "^3.3.3"
   },
-  "engines" : {
+  "engines": {
     "node": "22.x"
   },
   "packageManager": "pnpm@10.8.0+sha512.0e82714d1b5b43c74610193cb20734897c1d00de89d0e18420aebc5977fa13d780a9cb05734624e81ebd81cc876cd464794850641c48b9544326b5622ca29971"


### PR DESCRIPTION
Related to https://github.com/PaperMC/docs/pull/573 this PR try to make more clear what node engine version need to use also improvement the github action by using compose for a few "duplicate" steps.