### PR TITLE
Removed outdated warning

### DIFF
--- a/src/content/docs/paper/dev/api/component-api/i18n.md
+++ b/src/content/docs/paper/dev/api/component-api/i18n.md
@@ -28,13 +28,6 @@ Vanilla Minecraft handles translations on the client by using the language files
 in a resource pack, server-side translations are the only alternative. They work anywhere the component API exists, except for [`ItemStack`](jd:paper:org.bukkit.inventory.ItemStack)
 display text like the display name or lore. So chat, entity display names, scoreboards, tab lists, etc., all support translations.
 
-:::caution
-
-The player's language as declared in the settings packet sent by the client arrives **after** the player has joined the server, so there are no guarantees that
-translations will work for a client that is joining during the [`PlayerJoinEvent`](jd:paper:org.bukkit.event.player.PlayerJoinEvent) or any earlier event.
-You can listen for the first [`PlayerClientOptionsChangeEvent`](jd:paper:com.destroystokyo.paper.event.player.PlayerClientOptionsChangeEvent)
-after joining to know with 100% certainty what language the client that joined is using.
-
 :::
 
 ## Examples


### PR DESCRIPTION
The player's locale is initialized in the config phase, which happens before the join event, so this warning is not required anymore.