### PR TITLE
Fix typo in region-logic.md

### DIFF
--- a/src/content/docs/folia/admin/reference/region-logic.md
+++ b/src/content/docs/folia/admin/reference/region-logic.md
@@ -278,7 +278,7 @@ invariants #2 and #3 can be met.
 
 At the end of a tick, the region's new state is not immediately known.
 
-First, tt first must process its pending merges.
+First, the region must process its pending merges.
 
 After it processes its pending merges, it must then check if the
 region is now pending merge into any other region. If it is, then


### PR DESCRIPTION
Very minor spelling/grammar fix which bugged me when reading the folia docs