### PR TITLE
Highlight the config section the link points to

### DIFF
--- a/src/components/ConfigNode.astro
+++ b/src/components/ConfigNode.astro
@@ -85,6 +85,20 @@ const formatDefault = (value?: string): Default => {
 </div>
 
 <style>
+  details:target {
+    border-radius: 0.5rem;
+    padding-block: 0.3rem;
+    padding-inline: 0.5rem;
+  }
+
+  html[data-theme="dark"] details:target {
+    background-color: rgba(255, 255, 255, 0.1);
+  }
+
+  html[data-theme="light"] details:target {
+    background-color: rgba(0, 0, 0, 0.1);
+  }
+
   .node {
     padding-left: 1.25rem;
     font-size: var(--sl-text-xs);


### PR DESCRIPTION
uses :target selector to highlight the hyperlinked option so it's easier to notice between all other options.

![image](https://github.com/user-attachments/assets/276bca2c-3c1e-4741-b5d2-5db2f5db318e)

![image](https://github.com/user-attachments/assets/71adec2b-f715-4338-8294-fbe1c0eef6f3)
