### PR TITLE
add prop for velocity packet threshold validation

### DIFF
--- a/src/content/docs/velocity/admin/reference/system-properties.md
+++ b/src/content/docs/velocity/admin/reference/system-properties.md
@@ -70,6 +70,11 @@ The default value shown may not be set for the property but will only be used by
 - **default**: `false`
 - **description**: Whether packet decoding errors should be logged extensively.
 
+#### velocity.skip-uncompressed-packet-size-validation
+
+- **default**: `false`
+- **description**: Whether to skip the validation of uncompressed packet sizes, this is useful to allow modded setups to send uncompressed packets over the threshold.
+
 #### velocity.increased-compression-cap
 
 - **default**: `false`


### PR DESCRIPTION
Adds the system property added in velocity to allow skipping the validation of
uncompressed packets sizes. Not sure on the wording, however.
