### PR TITLE
Remove Experimental from certain API

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -162,10 +162,6 @@ export default defineConfig({
                         {
                           label: "Command API",
                           collapsed: true,
-                          badge: {
-                            text: "Experimental",
-                            variant: "danger",
-                          },
                           items: [
                             {
                               label: "Basics",

--- a/src/content/docs/paper/dev/api/command-api/basics/introduction.md
+++ b/src/content/docs/paper/dev/api/command-api/basics/introduction.md
@@ -11,12 +11,6 @@ It offers many advantages above the previously widely used Bukkit command system
 - Integration with reload events, allowing the definition of commands usable in datapacks.
 - Easier creation of subcommands.
 
-:::danger[Experimental]
-
-Paper's command system is still experimental and may change in the future.
-
-:::
-
 :::note
 
 To see a comparison between the new Brigadier system and the old Bukkit system, [click here](/paper/dev/command-api/misc/comparison-bukkit-brigadier).

--- a/src/content/docs/paper/dev/api/command-api/misc/comparison-bukkit-brigadier.md
+++ b/src/content/docs/paper/dev/api/command-api/misc/comparison-bukkit-brigadier.md
@@ -4,12 +4,6 @@ description: A comparison between Brigadier and Bukkit commands.
 slug: paper/dev/command-api/misc/comparison-bukkit-brigadier
 ---
 
-:::danger[Experimental]
-
-Paper's command system is still experimental and may change in the future.
-
-:::
-
 ## Registering commands
 ### The old Bukkit way
 

--- a/src/content/docs/paper/dev/api/lifecycle.md
+++ b/src/content/docs/paper/dev/api/lifecycle.md
@@ -2,22 +2,12 @@
 title: Lifecycle API
 description: A guide to Paper's Lifecycle API.
 slug: paper/dev/lifecycle
-sidebar:
-  badge:
-    text: Experimental
-    variant: danger
 ---
 
 The lifecycle API can be used for lifecycle-related registration. It is currently used by the
 Brigadier command API. It is planned to be used for the Registry Modification API as well.
 Generally, systems that are initialized very early in the startup process can take advantage of this
 event system.
-
-:::danger[Experimental]
-
-The Lifecycle API and anything that uses it is currently experimental and may change in the future.
-
-:::
 
 ## LifecycleEventManager
 


### PR DESCRIPTION
paper-pr: PaperMC/Paper#12712

might be nice to add a comment to lifecycle with something like "Although the system itself isn't experimental anymore, most of the events that use it are still experimental". though i am not sure we will need that