### PR TITLE
feat: update velocity docs for events priority

### DIFF
--- a/src/content/docs/velocity/dev/api/event.md
+++ b/src/content/docs/velocity/dev/api/event.md
@@ -40,12 +40,12 @@ State the desired order in the `@Subscribe` annotation:
 ```java
 @Subscribe(priority = 10)
 public void onPlayerChatFirst(PlayerChatEvent event) {
-	// do first stuff
+    // this method fires first
 }
 
 @Subscribe(priority = 5)
 public void onPlayerChat(PlayerChatEvent event) {
-  // do other stuff with the change from the first listener
+    // this method fires after the one above
 }
 ```
 


### PR DESCRIPTION
This PR close https://github.com/PaperMC/docs/issues/645 where the order/priority docs for events are outdated with the current behaviour

- PostOrder.CUSTOM not necesary since https://github.com/PaperMC/Velocity/commit/7392cd6574fcc5b1496fe4c3ac2b6fa7c8e993d7
- order field for Subscribe deprecated since https://github.com/PaperMC/Velocity/commit/4f227badc20dc30b0f6d84b5349c8809481dcbb1