### PR TITLE
feat: document mojang.sessionserver system property

### DIFF
--- a/src/content/docs/velocity/admin/reference/system-properties.md
+++ b/src/content/docs/velocity/admin/reference/system-properties.md
@@ -45,6 +45,11 @@ The default value shown may not be set for the property but will only be used by
 - **default**: `true`
 - **description**: Overrides `force-key-authentication` from the config. If not set, it will be automatically set to the current config value.
 
+#### mojang.sessionserver
+
+- **default**: `https://sessionserver.mojang.com/session/minecraft/hasJoined`
+- **description**: Full URL of the `hasJoined` endpoint on the session server used for authentication.
+
 #### velocity.natives-tmpdir
 
 - **default**: `unset`


### PR DESCRIPTION
This system property was introduced in https://github.com/PaperMC/Velocity/pull/560 but was never documented.