### PR TITLE
Particles 1.21.9

### DIFF
--- a/src/utils/versions.ts
+++ b/src/utils/versions.ts
@@ -66,8 +66,7 @@ const findLatest = async (project: Project): Promise<string> => {
 
 const paperProject = await fetchProject("paper");
 
-// export const LATEST_PAPER_RELEASE = await findLatest(paperProject);
-export const LATEST_PAPER_RELEASE = "1.21.10";
+export const LATEST_PAPER_RELEASE = await findLatest(paperProject);
 
 const velocityProject = await fetchProject("velocity");
 


### PR DESCRIPTION
This PR updates docs to match changes to particles in 1.21.9. As of writing this comment 1.21.9 is not out yet and therefore JD links are missing for SpellColorOptions and whatever will be used for dragon breath's power argument.