### PR TITLE
bump(dialogs): bump written version of dialog API to 1.21.8

### DIFF
--- a/src/content/docs/paper/dev/api/dialogs.mdx
+++ b/src/content/docs/paper/dev/api/dialogs.mdx
@@ -2,7 +2,7 @@
 title: Dialog API
 description: A guide to the dialog API introduced in 1.21.7.
 slug: paper/dev/dialogs
-version: 1.21.7
+version: 1.21.8
 sidebar:
   badge:
     text: Experimental


### PR DESCRIPTION
This PR bump the version of Written Version of [Dialog API](https://docs.papermc.io/paper/dev/dialogs) just to be sure that developers have all the specified methods on the documentation.

On 09-21-2025, I asked on the PaperMC discord server about `Audience#closeDialog` method specified in the docs and the version needed to be able to use it which you can find here : https://discord.com/channels/289587909051416579/289587909051416579/1419372618359767261

And the PaperMC Developer @jpenilla told me that it was better to bump the Written Version of that page instead of adding a warning about this method.