### PR TITLE
chore: improve documentation for the Dialog API

### DIFF
--- a/src/content/docs/paper/dev/api/dialogs.mdx
+++ b/src/content/docs/paper/dev/api/dialogs.mdx
@@ -256,7 +256,7 @@ public class ServerJoinListener implements Listener {
 
         // Construct a new completable future without a task.
         CompletableFuture<Boolean> response = new CompletableFuture<>();
-        // Complete the future if nothing has been done after two minutes.
+        // Complete the future if nothing has been done after one minute.
         response.completeOnTimeout(false, 1, TimeUnit.MINUTES);
 
         // Put it into our map.

--- a/src/content/docs/paper/dev/api/dialogs.mdx
+++ b/src/content/docs/paper/dev/api/dialogs.mdx
@@ -304,6 +304,14 @@ public class ServerJoinListener implements Listener {
     }
 
     /**
+     * An event handler for cleanup the map to avoid unnecessary entry buildup.
+     */
+    @EventHandler
+    void onConnectionClose(PlayerConnectionCloseEvent event) {
+        awaitingResponse.remove(event.getPlayerUniqueId());
+    }
+
+    /**
      * Simple utility method for setting a connection's dialog response result.
      */
     private void setConnectionJoinResult(UUID uniqueId, boolean value) {

--- a/src/content/docs/paper/dev/api/dialogs.mdx
+++ b/src/content/docs/paper/dev/api/dialogs.mdx
@@ -235,7 +235,7 @@ public class ServerJoinListener implements Listener {
     /**
      * A map for holding all currently connecting players.
      */
-    private final Map<PlayerCommonConnection, CompletableFuture<Boolean>> awaitingResponse = new HashMap<>();
+    private final Map<UUID, CompletableFuture<Boolean>> awaitingResponse = new ConcurrentHashMap<>();
 
     @EventHandler
     void onPlayerConfigure(AsyncPlayerConnectionConfigureEvent event) {
@@ -248,23 +248,31 @@ public class ServerJoinListener implements Listener {
             return;
         }
 
+        PlayerConfigurationConnection connection = event.getConnection();
+        UUID uniqueId = connection.getProfile().getId();
+        if (uniqueId == null) {
+            return;
+        }
+
         // Construct a new completable future without a task.
         CompletableFuture<Boolean> response = new CompletableFuture<>();
+        // Complete the future if nothing has been done after two minutes.
+        response.completeOnTimeout(false, 1, TimeUnit.MINUTES);
 
         // Put it into our map.
-        awaitingResponse.put(event.getConnection(), response);
+        awaitingResponse.put(uniqueId, response);
 
+        Audience audience = connection.getAudience();
         // Show the connecting player the dialog.
-        event.getConnection().getAudience().showDialog(dialog);
+        audience.showDialog(dialog);
 
         // Wait until the future is complete. This step is necessary in order to keep the player in the configuration phase.
         if (!response.join()) {
+            // We close the dialog manually because the client might not do it on its own.
+            audience.closeDialog();
             // If the response is false, they declined. Therefore, we kick them from the server.
-            event.getConnection().disconnect(Component.text("You hate Paper-chan :(", NamedTextColor.RED));
+            connection.disconnect(Component.text("You hate Paper-chan :(", NamedTextColor.RED));
         }
-
-        // We clean the map to avoid unnecessary entry buildup.
-        awaitingResponse.remove(event.getConnection());
     }
 
     /**
@@ -272,22 +280,32 @@ public class ServerJoinListener implements Listener {
      */
     @EventHandler
     void onHandleDialog(PlayerCustomClickEvent event) {
-        Key key = event.getIdentifier();
+        // Handle custom click only for configuration connection.
+        if (!(event.getCommonConnection() instanceof PlayerConfigurationConnection configurationConnection)) {
+            return;
+        }
 
+        UUID uniqueId = configurationConnection.getProfile().getId();
+        if (uniqueId == null) {
+            return;
+        }
+
+        Key key = event.getIdentifier();
         if (key.equals(Key.key("papermc:paperchan/disagree"))) {
             // If the identifier is the same as the disagree one, set the connection result to false.
-            setConnectionJoinResult(event.getCommonConnection(), false);
+            setConnectionJoinResult(uniqueId, false);
         } else if (key.equals(Key.key("papermc:paperchan/agree"))) {
             // If it is the same as the agree one, set the result to true.
-            setConnectionJoinResult(event.getCommonConnection(), true);
+            setConnectionJoinResult(uniqueId, true);
         }
     }
 
     /**
      * Simple utility method for setting a connection's dialog response result.
      */
-    private void setConnectionJoinResult(PlayerCommonConnection connection, boolean value) {
-        CompletableFuture<Boolean> future = awaitingResponse.get(connection);
+    private void setConnectionJoinResult(UUID uniqueId, boolean value) {
+        // We get the value and clean the map to avoid unnecessary entry buildup.
+        CompletableFuture<Boolean> future = awaitingResponse.remove(uniqueId);
         if (future != null) {
             future.complete(value);
         }

--- a/src/content/docs/paper/dev/api/dialogs.mdx
+++ b/src/content/docs/paper/dev/api/dialogs.mdx
@@ -273,6 +273,9 @@ public class ServerJoinListener implements Listener {
             // If the response is false, they declined. Therefore, we kick them from the server.
             connection.disconnect(Component.text("You hate Paper-chan :(", NamedTextColor.RED));
         }
+
+        // We clean the map to avoid unnecessary entry buildup.
+        awaitingResponse.remove(uniqueId);
     }
 
     /**
@@ -304,8 +307,7 @@ public class ServerJoinListener implements Listener {
      * Simple utility method for setting a connection's dialog response result.
      */
     private void setConnectionJoinResult(UUID uniqueId, boolean value) {
-        // We get the value and clean the map to avoid unnecessary entry buildup.
-        CompletableFuture<Boolean> future = awaitingResponse.remove(uniqueId);
+        CompletableFuture<Boolean> future = awaitingResponse.get(uniqueId);
         if (future != null) {
             future.complete(value);
         }


### PR DESCRIPTION
This PR improves the documentation for the dialog API example, as several issues were noticed after reading it. The PR includes the following fixes:

- Using UUID instead of PlayerCommonConnection
- Using ConcurrentHashMap, since events are triggered in different threads
- One-minute timeout to prevent the player connection from hanging indefinitely
- Manually closing the dialog using Audience#closeDialog, as the client sometimes doesn't do this if no button was pressed (e.g., in case of a timeout)
- All of this includes a bit of adherence to best practices ;)