### PR TITLE
Fix community library links

### DIFF
--- a/src/content/docs/adventure/community-libraries.mdx
+++ b/src/content/docs/adventure/community-libraries.mdx
@@ -28,10 +28,10 @@ They typically have no dependencies on a specific platform, just Adventure and p
 {/* spellchecker:off */}
 Name                        | Description                                                           | Link
 ----------------------------|-----------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------
-adventure-binary-serializer | Serializer for converting to packed bytes                             | [Moulberry/adventure-binary-serializer](https://github.com/Moulberry/adventure-binary-serializer/>)
-EnhancedLegacyText          | Alternative input format that is legacy compatible with new features  | [Vankka/EnhancedLegacyText](https://github.com/Vankka/EnhancedLegacyText>)
-MCDiscordReserializer       | Serializers for going between Minecraft & Discord                     | [Vankka/MCDiscordReserializer](https://github.com/Vankka/MCDiscordReserializer>)
-Minedown                    | A markdown-style format for representing components                   | [Phoenix616/MineDown](https://github.com/Phoenix616/MineDown>)
+adventure-binary-serializer | Serializer for converting to packed bytes                             | [Moulberry/adventure-binary-serializer](https://github.com/Moulberry/adventure-binary-serializer)
+EnhancedLegacyText          | Alternative input format that is legacy compatible with new features  | [Vankka/EnhancedLegacyText](https://github.com/Vankka/EnhancedLegacyText)
+MCDiscordReserializer       | Serializers for going between Minecraft & Discord                     | [Vankka/MCDiscordReserializer](https://github.com/Vankka/MCDiscordReserializer)
+Minedown                    | A markdown-style format for representing components                   | [Phoenix616/MineDown](https://github.com/Phoenix616/MineDown)
 {/* spellchecker:on */}
 
 ## Libraries that use Adventure


### PR DESCRIPTION
These links lead to a 404

Was also mentioned here but seems to have been forgotten: https://github.com/PaperMC/docs/pull/573#discussion_r2097747453