### PR TITLE
fix: Use new Wiki Article for RAW-JSON/TextComponent

### DIFF
--- a/src/content/docs/adventure/faq.md
+++ b/src/content/docs/adventure/faq.md
@@ -16,7 +16,7 @@ In vanilla Minecraft, some places where components are rendered have parent styl
 
 - Test on a vanilla client, without any mods or resource packs. Modded clients (such as Badlion), client mods, and even resource packs can break many elements of the modern JSON chat format and mess with incoming chat packets in ways that cause a myriad of issues.
 - Try without other plugins/mods. If another plugin/mod is modifying outgoing packets or formatting chat messages, this could cause a loss of formatting in the messages you send. Try without any other plugins to see if any are causing issues.
-- For RGB colors, test on a client of at least version *1.16*. Mojang added RGB support in this version. The JSON message format has evolved over time and has had many new additions since its introduction many, many years ago. For a full version history, see [the Minecraft wiki](https://minecraft.wiki/w/Raw_JSON_text_format).
+- For RGB colors, test on a client of at least version *1.16*. Mojang added RGB support in this version. The JSON message format has evolved over time and has had many new additions since its introduction many, many years ago. For a full version history, see [the Minecraft wiki](https://minecraft.wiki/w/Text_component_format).
 
 ## How can I support both MiniMessage and legacy (§-code) formatting?
 

--- a/src/content/docs/adventure/minimessage/format.mdx
+++ b/src/content/docs/adventure/minimessage/format.mdx
@@ -54,7 +54,7 @@ the opening quote character can be escaped (`'` or `"`). In either place, the es
 In locations where escaping is not supported, the literal escape character will be passed through. In locations where escaping *is* supported but a literal escape character is desired, the escape character can itself be escaped to produce a `\`.
 
 The default tags try to represent components in a manner compatible with Vanilla, but simplifying some elements. It might be helpful to
-use [the Minecraft wiki](https://minecraft.wiki/w/Raw_JSON_text_format) as a reference for the Vanilla component system, especially
+use [the Minecraft wiki](https://minecraft.wiki/w/Text_component_format) as a reference for the Vanilla component system, especially
 for things like the actions and values of click and hover events.
 
 The [MiniMessage Web Viewer](https://webui.advntr.dev) allows testing MiniMessage text locally, without having to spin up a Minecraft instance.
@@ -205,7 +205,7 @@ Tag
 
 Arguments
   * `_action_`, the type of click event, one of [this list](https://jd.advntr.dev/api/latest/net/kyori/adventure/text/event/ClickEvent.Action.html#enum.constant.summary)
-  * `_value_`, the argument for that particular event, refer to [the minecraft wiki](https://minecraft.wiki/w/Raw_JSON_text_format)
+  * `_value_`, the argument for that particular event, refer to [the minecraft wiki](https://minecraft.wiki/w/Text_component_format)
 
 Examples
 ```mm

--- a/src/content/docs/paper/dev/api/component-api/intro.md
+++ b/src/content/docs/paper/dev/api/component-api/intro.md
@@ -145,7 +145,7 @@ of this format.
 
 :::note[In-Depth Documentation]
 
-The JSON format is fully documented on the [Minecraft Wiki](https://minecraft.wiki/w/Raw_JSON_text_format).
+The JSON format is fully documented on the [Minecraft Wiki](https://minecraft.wiki/w/Text_component_format).
 
 :::
 


### PR DESCRIPTION
This just replace the mentions for the Wiki RAW-JSON to the new article for avoid the unnecesary redirection.