### PR TITLE
fix: replace mention of docs.advntr.dev to docs.papermc.io

### DIFF
--- a/src/config/paper/paper-global.yml
+++ b/src/config/paper/paper-global.yml
@@ -229,7 +229,7 @@ messages:
     description: >-
       Default message sent to players when they have insufficient permissions
       for an action, formatted with
-      [MiniMessage](https://docs.advntr.dev/minimessage/). Plugins may override
+      [MiniMessage](/adventure/minimessage/). Plugins may override
       this for their commands
   use-display-name-in-quit-message:
     default: "false"
@@ -242,23 +242,23 @@ messages:
       description: >-
         Message sent to players when Mojang's authentication servers are
         unreachable. Formatted using
-        [MiniMessage](https://docs.advntr.dev/minimessage/).
+        [MiniMessage](/adventure/minimessage/).
     connection-throttle:
       default: Connection throttled! Please wait before reconnecting.
       description: >-
         Message sent to players when they are throttled for connecting too
         frequently. Formatted using
-        [MiniMessage](https://docs.advntr.dev/minimessage/).
+        [MiniMessage](/adventure/minimessage/).
     flying-player:
       default: "<lang:multiplayer.disconnect.flying>"
       description: >-
         Message sent to players who are detected flying. Formatted using
-        [MiniMessage](https://docs.advntr.dev/minimessage/).
+        [MiniMessage](/adventure/minimessage/).
     flying-vehicle:
       default: "<lang:multiplayer.disconnect.flying>"
       description: >-
         Message sent to players who are detected riding a flying vehicle.
-        Formatted using [MiniMessage](https://docs.advntr.dev/minimessage/).
+        Formatted using [MiniMessage](/adventure/minimessage/).
 misc:
   fix-entity-position-desync:
     vanilla: "false"
@@ -348,7 +348,7 @@ packet-limiter:
     default: "<red><lang:disconnect.exceeded_packet_rate>"
     description: >-
       The message players are kicked with for sending too many packets.
-      Formatted using [MiniMessage](https://docs.advntr.dev/minimessage/).
+      Formatted using [MiniMessage](/adventure/minimessage/).
   overrides:
     header:
       message: >-

--- a/src/content/docs/paper/dev/api/component-api/intro.md
+++ b/src/content/docs/paper/dev/api/component-api/intro.md
@@ -107,7 +107,7 @@ We recommend using this format for user-facing input such as commands or configu
 
 :::note[In-Depth Documentation]
 
-MiniMessage is a part of Adventure, and you can find its documentation on [Adventure's documentation](https://docs.advntr.dev/minimessage/index.html).
+MiniMessage is a part of Adventure, and you can find its documentation on [Adventure's documentation](/adventure/minimessage/).
 
 :::
 
@@ -172,7 +172,7 @@ This conversion is lossless and is the preferred form of serialization for compo
 Converts between `Component`
 and a MiniMessage-formatted string. This conversion is lossless and is the preferred form of
 serialization for components that have to be edited by users. There is also extensive customization you can add to the
-serializer, which is [documented here](https://docs.advntr.dev/minimessage/api.html#getting-started).
+serializer, which is [documented here](/adventure/minimessage/api/#getting-started).
 
 ### [`PlainTextComponentSerializer`](https://jd.advntr.dev/text-serializer-plain/latest)
 

--- a/src/content/docs/paper/dev/api/event-api/chat-event.md
+++ b/src/content/docs/paper/dev/api/event-api/chat-event.md
@@ -140,4 +140,4 @@ Now you can see that the message is rendered as we wanted it to be.
 
 That is all you need to know about the new chat event and its renderer.
 Of course there are many more things you can do with components in general.
-If you want to learn more about components, you can read the [Component Documentation](https://docs.advntr.dev/text.html).
+If you want to learn more about components, you can read the [Component Documentation](/adventure/text/).

--- a/src/content/docs/paper/dev/getting-started/how-do-plugins-work.md
+++ b/src/content/docs/paper/dev/getting-started/how-do-plugins-work.md
@@ -121,5 +121,5 @@ rich text. This means that plugins can send messages that contain things like co
 Colors were always possible, but only through the use of legacy color codes.
 
 Paper implements a library called `Adventure` that makes it easy to create and send messages to players. Learn more
-about the `Adventure` API [here](https://docs.advntr.dev/) from their docs or our docs
+about the `Adventure` API [here](/adventure/) from their docs or our docs
 [here](/paper/dev/component-api/introduction).

--- a/src/content/docs/velocity/admin/reference/commands.md
+++ b/src/content/docs/velocity/admin/reference/commands.md
@@ -69,7 +69,7 @@ This command can only be executed from console.
 
 When run, this will gracefully shut down the Velocity proxy.
 All players will be disconnected from the proxy, and plugins will have a chance to finish up before the proxy shuts down.
-An optional reason can be given, either as JSON or with [MiniMessage Format](https://docs.advntr.dev/minimessage/format.html).
+An optional reason can be given, either as JSON or with [MiniMessage Format](/adventure/minimessage/format/).
 
 If the provided message starts with `"`, `[`, or `{`, then the message is attempted to be parsed as JSON.
 If this parsing fails, or the message starts with anything else, the message will be parsed as MiniMessage.

--- a/src/content/docs/velocity/admin/reference/configuration.md
+++ b/src/content/docs/velocity/admin/reference/configuration.md
@@ -18,7 +18,7 @@ There are a few "special" data types in the Velocity configuration.
 
 ### Chat
 
-Chat messages may be provided in [MiniMessage](https://docs.advntr.dev/minimessage/format.html) format.
+Chat messages may be provided in [MiniMessage](/adventure/minimessage/format/) format.
 
 RGB support is available for Minecraft 1.16 and later versions.
 
@@ -35,7 +35,7 @@ These settings mostly cover the basic, most essential settings of the proxy.
 |------------------------------------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `config-version`                   | String  | This is the current config version used by Velocity. You should not alter this setting.                                                                                                                                                                            |
 | `bind`                             | Address | This tells the proxy to accept connections on a specific IP. By default, Velocity will listen for connections on all IP addresses on the computer on port 25565.                                                                                                   |
-| `motd`                             | Chat    | This allows you to change the message shown to players when they add your server to their server list. You can use [MiniMessage format](https://docs.advntr.dev/minimessage/format.html).                                                                          |
+| `motd`                             | Chat    | This allows you to change the message shown to players when they add your server to their server list. You can use [MiniMessage format](/adventure/minimessage/format/).                                                                                           |
 | `show-max-players`                 | Integer | This allows you to customize the number of "maximum" players in the player's server list. Note that Velocity doesn't have a maximum number of players it supports.                                                                                                 |
 | `online-mode`                      | Boolean | Should we authenticate players with Mojang? By default, this is on.                                                                                                                                                                                                |
 | `force-key-authentication`         | Boolean | Should the proxy enforce the new public key security standard? By default, this is on.                                                                                                                                                                             |

--- a/src/content/docs/velocity/dev/how-to/porting-from-velocity-1.md
+++ b/src/content/docs/velocity/dev/how-to/porting-from-velocity-1.md
@@ -14,7 +14,7 @@ Velocity 3.3.x and above now requires Java 17 and above.
 ## Removal of legacy dependencies
 
 We removed all support for the old `text` 3 library. For `text` 3.x.x (and all the APIs that depend
-on it), direct equivalents are available in [Adventure](https://docs.advntr.dev/), which was
+on it), direct equivalents are available in [Adventure](/adventure/), which was
 introduced in Velocity 1.1.0.
 
 `toml4j`, deprecated in Velocity 1.1.0 (as it is no longer maintained), has not been removed to


### PR DESCRIPTION
This PR replaces the mentions to the docs.advntr.dev to the migrated docs in docs.papermc.io