### PR TITLE
fix(paper/dev): display guide use wrong setTeleportDuration values

### DIFF
--- a/src/content/docs/paper/dev/api/entity-api/display-entities.md
+++ b/src/content/docs/paper/dev/api/entity-api/display-entities.md
@@ -211,7 +211,7 @@ other properties of the transformation, those too will be interpolated, which ma
 // new position will be 10 blocks higher
 Location newLocation = display.getLocation().add(0, 10, 0);
 
-display.setTeleportDuration(20 * 5); // the movement will take 5 seconds (1 second = 20 ticks)
+display.setTeleportDuration(20 * 2); // the movement will take 2 seconds (1 second = 20 ticks)
 display.teleport(newLocation); // perform the movement
 ```
 


### PR DESCRIPTION
This PR fix an issue in the example for Display Entity setTeleportDuration use where the value is out of the valid range.
ref:
- https://canary.discord.com/channels/289587909051416579/555462289851940864/1440109499951218952
- https://minecraft.wiki/w/Display