### PR TITLE
Add mention of Snap to FAQ entry on plugins

### DIFF
--- a/src/content/docs/velocity/admin/getting-started/faq.md
+++ b/src/content/docs/velocity/admin/getting-started/faq.md
@@ -26,10 +26,10 @@ addition, plugins that support BungeeCord but only require that they are install
 (nothing on the proxy) typically use the BungeeCord plugin messaging channel, which is supported
 natively by the latest versions of Velocity.
 
-If no Velocity port or alternative is available then the third-party project [Snap](https://hangar.papermc.io/Phoenix616/Snap)
-offers an experimental way to run BungeeCord/Waterfall plugins on Velocity, however not all plugins
-can be supported and there are some major drawbacks which need to be considered before use.
-Snap is not maintained by, or affiliated with, the Velocity project.
+If no Velocity port or alternative is available, the third-party project [Snap](https://hangar.papermc.io/Phoenix616/Snap)
+offers an experimental way to run BungeeCord/Waterfall plugins on Velocity.
+Note that not all plugins may work correctly, so you should always do your own testing.
+Snap is not maintained by or affiliated with the Velocity project.
 
 ## Help, I can't connect to my server!
 


### PR DESCRIPTION
My [Snap project](https://hangar.papermc.io/Phoenix616/Snap) was until now only mentioned on the comparison page but people might be looking at the FAQ too to find out about what kind of plugins Velocity can run. This adds a note to the FAQ alongside (imo) amble warnings about it being a last resort and the same disclaimer as on the comparison page.