### PR TITLE
Clarify matching of online-mode config option for velocity forwarding

### DIFF
--- a/src/content/docs/velocity/admin/getting-started/forwarding.md
+++ b/src/content/docs/velocity/admin/getting-started/forwarding.md
@@ -54,7 +54,7 @@ You also need to disable BungeeCord forwarding if you had it enabled beforehand.
 
 In `config/paper-global.yml`, set `proxies.velocity.enabled` to true and
 `proxies.velocity.secret`, to match the secret in your `forwarding.secret` file. You must also set
-`proxies.velocity.online-mode` to the `online-mode` setting in your `velocity.toml`. Once
+`proxies.velocity.online-mode` to match the `online-mode` setting in your `velocity.toml`. Once
 you're done editing `paper-global.yml`, reboot your server.
 
 :::note


### PR DESCRIPTION
I was abit confused when I first read the snippet "set`proxies.velocity.online-mode` to the `online-mode` setting". At first, thinking it was to set the value of that config option to `online-mode`. I ultermately figured out it was to match the config option, but I figure it's probably a good idea to just explicitly put the word "to _**match**_ the".