### PR TITLE
Add missing documentation of advanced Velocity config options

### DIFF
--- a/src/content/docs/velocity/admin/reference/configuration.md
+++ b/src/content/docs/velocity/admin/reference/configuration.md
@@ -78,6 +78,12 @@ These settings mostly cover the basic, most essential settings of the proxy.
 | `log-command-executions`                   | Boolean | Determines whether or not the proxy should log all commands run by the user.                                                                                                                            |
 | `log-player-connections`                   | Boolean | Enables logging of player connections when connecting to the proxy, switching servers and disconnecting from the proxy.                                                                                 |
 | `accepts-transfers`                        | Boolean | Determines whether or not the proxy accepts incoming transfers from other servers. If disabled, the proxy will disconnect transferred clients.                                                          |
+| `enable-reuse-port`                        | Boolean | Enables support for SO_REUSEPORT. This may help the proxy scale better on multicore systems with a lot of incoming connections, and provide better CPU utilization than the existing strategy of having a single thread accepting connections and distributing them to worker threads. Requires Linux or macOS. |
+| `command-rate-limit`                       | Integer | How fast (in milliseconds) are clients allowed to send commands after the last command. By default this is 50ms (20 commands per second) |
+| `forward-commands-if-rate-limited`         | Boolean | Should we forward commands to the backend upon being rate limited? This will forward the command to the server instead of processing it on the proxy. Since most server implementations have a rate limit, this will prevent the player from being able to send excessive commands to the server. |
+| `kick-after-rate-limited-commands`         | Integer | How many commands are allowed to be sent after the rate limit is hit before the player is kicked? Setting this to 0 or lower will disable this feature. |
+| `tab-complete-rate-limit`                  | Integer | How fast (in milliseconds) are clients allowed to send tab completions after the last tab completion |
+| `kick-after-rate-limited-tab-completes`    | Integer | How many tab completions are allowed to be sent after the rate limit is hit before the player is kicked? Setting this to 0 or lower will disable this feature. |
 
 ## `query` section
 


### PR DESCRIPTION
This adds documentation for several missing keys of Velocity's config. The explanations are taken from the default config file.