### PR TITLE
fix(velocity): explicitly add the annotation processor in Maven

### DIFF
--- a/src/content/docs/velocity/dev/getting-started/creating-your-first-plugin.mdx
+++ b/src/content/docs/velocity/dev/getting-started/creating-your-first-plugin.mdx
@@ -90,7 +90,7 @@ system's documentation ([Gradle](https://docs.gradle.org/current/userguide/userg
     }
     ```
   </TabItem>
-  <TabItem label="Maven">
+  <TabItem label="Maven 4+">
     :::caution
 
     If you're using JDK 23 or later, you must add the annotation processor manually to your `pom.xml`, as described in the example.
@@ -114,12 +114,40 @@ system's documentation ([Gradle](https://docs.gradle.org/current/userguide/userg
           <version>\{LATEST_VELOCITY_RELEASE}</version>
           <scope>provided</scope>
         </dependency>
-        <!-- add the annotation processor (Maven 4+) -->
+        <!-- add the annotation processor -->
         <dependency>
           <groupId>com.velocitypowered</groupId>
           <artifactId>velocity-api</artifactId>
           <version>\{LATEST_VELOCITY_RELEASE}</version>
           <type>processor</type>
+        </dependency>
+      </dependencies>
+    </project>
+    ```
+  </TabItem>
+  <TabItem label="Maven 3">
+    :::caution
+
+    If you're using JDK 23 or later, you must add the annotation processor manually to your `pom.xml`, as described in the example.
+    See the [Maven documentation](https://maven.apache.org/plugins/maven-compiler-plugin-4.x/examples/annotation-processor.html) for more information.
+
+    :::
+
+    ```xml title="pom.xml" replace
+    <project>
+      <repositories>
+        <repository>
+          <id>papermc</id>
+          <url>https://repo.papermc.io/repository/maven-public/</url>
+        </repository>
+      </repositories>
+
+      <dependencies>
+        <dependency>
+          <groupId>com.velocitypowered</groupId>
+          <artifactId>velocity-api</artifactId>
+          <version>\{LATEST_VELOCITY_RELEASE}</version>
+          <scope>provided</scope>
         </dependency>
       </dependencies>
 
@@ -129,7 +157,7 @@ system's documentation ([Gradle](https://docs.gradle.org/current/userguide/userg
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
             <configuration>
-              <!-- add the annotation processor (Maven 3) -->
+              <!-- add the annotation processor -->
               <annotationProcessorPaths>
                 <path>
                   <groupId>com.velocitypowered</groupId>


### PR DESCRIPTION
Apparently with JDK 23 the main classpath is no longer scanned, so it wouldn't find the annotation processor.