### PR TITLE
Explicitly add velocity-api as an AP in maven example

### DIFF
--- a/src/content/docs/velocity/dev/getting-started/creating-your-first-plugin.mdx
+++ b/src/content/docs/velocity/dev/getting-started/creating-your-first-plugin.mdx
@@ -108,6 +108,25 @@ system's documentation ([Gradle](https://docs.gradle.org/current/userguide/userg
           <scope>provided</scope>
         </dependency>
       </dependencies>
+
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <release>21</release> <!-- The Java version that you want to compile for -->
+              <annotationProcessorPaths>
+                <path>
+                  <groupId>com.velocitypowered</groupId>
+                  <artifactId>velocity-api</artifactId>
+                  <version>\{LATEST_VELOCITY_RELEASE}</version>
+                </path>
+              </annotationProcessorPaths>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </project>
     ```
   </TabItem>


### PR DESCRIPTION
Somewhere in between java 21 and 25 the compiler was changed to no longer automatically run annotation processors on the compile classpath by default, so this part is now necessary in the maven example.