### PR TITLE
feat: replace mentions of docs.advntr.dev to docs.papermc.io

### DIFF
--- a/src/content/docs/adventure/minimessage/api.mdx
+++ b/src/content/docs/adventure/minimessage/api.mdx
@@ -135,7 +135,7 @@ This helper can be used to efficiently apply a collection of styles with one tag
 
 ```java
 Component aTagExample() {
-  final String input = "Hello, <a:https://docs.advntr.dev>click me!</a> but not me!";
+  final String input = "Hello, <a:https://docs.papermc.io>click me!</a> but not me!";
   final MiniMessage extendedInstance = MiniMessage.builder()
     .editTags(b -> b.tag("a", MiniMessageTest::createA))
     .build();

--- a/src/content/docs/adventure/minimessage/index.md
+++ b/src/content/docs/adventure/minimessage/index.md
@@ -10,7 +10,7 @@ sidebar:
 The MiniMessage format is a simple string representation of chat components, designed to be easy for end users to learn, and for developers to extend.
 
 ```mm
-Hello <rainbow>world</rainbow>, isn't <blue><u><click:open_url:'https://docs.advntr.dev/minimessage'>MiniMessage</click></u></blue> fun?
+Hello <rainbow>world</rainbow>, isn't <blue><u><click:open_url:'https://docs.papermc.io/adventure/minimessage/'>MiniMessage</click></u></blue> fun?
 ```
 
 If you're looking to write messages with MiniMessage, take a look at the [MiniMessage Format](/adventure/minimessage/format), or if you're looking to develop software that uses MiniMessage, take a look at the [API overview](/adventure/minimessage/api).

--- a/src/content/docs/paper/dev/api/component-api/intro.md
+++ b/src/content/docs/paper/dev/api/component-api/intro.md
@@ -70,7 +70,7 @@ final Component component = text()
 :::note[In-Depth Documentation]
 
 For complete documentation on the Adventure Component API Paper and Velocity use, please look at the
-[Adventure documentation](https://docs.advntr.dev).
+[Adventure documentation](/adventure).
 
 :::
 


### PR DESCRIPTION
Noticed in https://github.com/PaperMC/Velocity/commit/7d0c002f89d1cc916fd7525bcb4f2a0f4bc31649 the docs still contains mentions for the old adventure docs this PR replace that for point to paper docs