### PR TITLE
Add Imperat framework to community libraries list

### DIFF
--- a/src/content/docs/adventure/community-libraries.mdx
+++ b/src/content/docs/adventure/community-libraries.mdx
@@ -65,6 +65,7 @@ Name                | Description                                               
 --------------------|-----------------------------------------------------------------------|----------------------------------------------------
 Cloud               | A general-purpose Java command dispatcher & framework                 | [Incendo/cloud](https://github.com/Incendo/cloud)
 Creative            | A resource-pack library for Minecraft: Java Edition                   | [unnamed/creative](https://github.com/unnamed/creative)
+Imperat             | An Enterprise command dispatching framework with optimal performance  | [MeveraStudios/Imperat](https://github.com/MeveraStudios/Imperat)
 Inventory Framework | An inventory framework for managing GUIs                              | [stefvanschie/IF](https://github.com/stefvanschie/IF)
 LiteCommands        | A annotation based command framework for Velocity, Bukkit, BungeeCord | [Rollczi/LiteCommands](https://github.com/Rollczi/LiteCommands)
 ProtocolSidebar     | An easy to use sidebar library for Paper/Spigot servers               | [CatCoderr/ProtocolSidebar](https://github.com/CatCoderr/ProtocolSidebar)


### PR DESCRIPTION
The library has explicit support for Adventure on all 4 platforms (Bukkit, Minestom, Bungeecord & Velocity)