### PR TITLE
chore(paper): replace bugs-legacy.mojang.com with mojira.dev

### DIFF
--- a/src/content/docs/paper/dev/api/component-api/intro.md
+++ b/src/content/docs/paper/dev/api/component-api/intro.md
@@ -33,7 +33,7 @@ representations in the legacy string format.
 Representing text as components is now the supported way of representing text for Paper and Velocity. They are used
 for almost all aspects of text being displayed to clients. Text like item names, lore, bossbars, team prefixes and
 suffixes, custom names, and much more all support components in respective APIs.
-[Mojang has stated](https://bugs-legacy.mojang.com/browse/MC-190605?focusedId=993040&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-993040)
+[Mojang has stated](https://mojira.dev/MC-190605#comment-993040)
 that client support for the legacy format with `§` will be removed in the future.
 
 


### PR DESCRIPTION
This PR replace the use of bugs-legacy and comments from mojang to mojira, the idea its avoid use a legacy domain who can be just removed or shutdown (or forget renew the SSL cert)