### PR TITLE
feat(paper): Remove compression-format from paper-global.yml

### DIFF
--- a/src/config/paper/paper-global.yml
+++ b/src/config/paper/paper-global.yml
@@ -489,12 +489,6 @@ unsupported-settings:
       possible, for example sand duplication. This
       setting is not recommended to be enabled, but is provided for those who
       wish to use it.
-  compression-format:
-    default: ZLIB
-    description: >-
-      Allows the server to customize the format of saved region files. This
-      supports ZLIB, GZIP, LZ4 and NONE, where None namely allows for compression to
-      be disabled
   oversized-item-component-sanitizer:
     dont-sanitize:
       vanilla: "[minecraft:container, minecraft:charged_projectiles, minecraft:bundle_contents]"

--- a/src/config/paper/server-properties.yml
+++ b/src/config/paper/server-properties.yml
@@ -212,7 +212,7 @@ rcon.port:
 region-file-compression:
   default: "deflate"
   description: >
-    Specifies the compression type used to compress region files. Possible values are: "deflate", "lz4" and "none".
+    Specifies the compression type used to compress region files. Possible values are: "deflate", "lz4", "none" and "gzip" (only available on Paper).
     If set to "none", region files will take up significantly more disk space, but it might make sense together with filesystem-level compression.
 require-resource-pack:
   default: "false"


### PR DESCRIPTION
Related to https://github.com/PaperMC/Paper/pull/13800

This PR remove the `compression-format` from `unsupported-settings` in `paper-global.yml`, also add a new option to `region-file-compression` in `server.properties`