### PR TITLE
feat(paper): document global config for misc.max-tracking-combat-entries

### DIFF
--- a/src/config/paper/paper-global.yml
+++ b/src/config/paper/paper-global.yml
@@ -284,6 +284,12 @@ misc:
       tick. If more players join, they will be postponed until later ticks to
       join but not kicked. This is not related to connection throttling found in
       bukkit.yml
+  max-tracking-combat-entries:
+    vanilla: "disabled"
+    default: "10240"
+    description: >-
+      The maximum number of combat entries that the server will track. Older
+      entries will be discarded.
   prevent-negative-villager-demand:
     default: "false"
     description: >-


### PR DESCRIPTION
Related to https://github.com/PaperMC/Paper/commit/4f184db3c9ebe3c2c9aa9ace681aad696254f272