### PR TITLE
Typo: "Support's" should be "Supports"

### DIFF
--- a/src/content/docs/adventure/platform/bukkit.mdx
+++ b/src/content/docs/adventure/platform/bukkit.mdx
@@ -15,7 +15,7 @@ Minecraft 1.7.10 through {LATEST_ADVENTURE_SUPPORTED_MC}.
 Adventure platform implementation for Bukkit/Spigot and the Minecraft/Bungeecord component serializers are no longer maintained.
 The Adventure team no longer provides support for using these libraries.
 
-We recommend that users of these libraries update to modern software that [natively support's Adventure](/adventure/platform/native) (e.g., [Paper](/paper)).
+We recommend that users of these libraries update to modern software that [natively supports Adventure](/adventure/platform/native) (e.g., [Paper](/paper)).
 
 :::
 

--- a/src/content/docs/adventure/platform/bungeecord.mdx
+++ b/src/content/docs/adventure/platform/bungeecord.mdx
@@ -15,7 +15,7 @@ forks, such as Waterfall.
 Adventure platform implementation for Bungeecord and the Bungeecord component serializer is no longer maintained.
 The Adventure team no longer provides support for using these libraries.
 
-We recommend that users of these libraries update to modern software that [natively support's Adventure](/adventure/platform/native) (e.g., [Velocity](/velocity)).
+We recommend that users of these libraries update to modern software that [natively supports Adventure](/adventure/platform/native) (e.g., [Velocity](/velocity)).
 
 :::
 

--- a/src/content/docs/adventure/platform/spongeapi.mdx
+++ b/src/content/docs/adventure/platform/spongeapi.mdx
@@ -14,7 +14,7 @@ Adventure provides a platform for SpongeAPI 7 for *Minecraft: Java Edition* 1.12
 Adventure platform implementation for SpongeAPI 7 is no longer maintained.
 The Adventure team no longer provides support for using these libraries.
 
-We recommend that users of these libraries update to modern software that [natively support's Adventure](/adventure/platform/native) (e.g., SpongeAPI 8+).
+We recommend that users of these libraries update to modern software that [natively supports Adventure](/adventure/platform/native) (e.g., SpongeAPI 8+).
 
 :::
 


### PR DESCRIPTION
"Support's" is not grammatically correct, "supports" should be used.

Just a single character fix I noticed when reading the page.