### PR TITLE
feat(paper): document world config for chunk unloads

### DIFF
--- a/src/config/paper/paper-world-defaults.yml
+++ b/src/config/paper/paper-world-defaults.yml
@@ -132,9 +132,9 @@ chunks:
   min-chunk-unload-fraction:
     default: "0.05"
     description: >-
-      The minimum fraction of chunks to unload each tick.
+      The minimum fraction of eligible chunks to unload each tick.
 
-      The final number of chunks unloads per tick is the maximum of
+      The final number of chunk unloads per tick is the maximum of
       min-chunk-unload-count and eligible-chunks * min-chunk-unload-fraction.
   prevent-moving-into-unloaded-chunks:
     default: "false"

--- a/src/config/paper/paper-world-defaults.yml
+++ b/src/config/paper/paper-world-defaults.yml
@@ -119,6 +119,23 @@ chunks:
     description: >-
       The maximum number of chunks the auto-save system will save in a single
       tick
+  min-chunk-unload-count:
+    vanilla: "2147483647"
+    default: "50"
+    description: >-
+      The minimum number of eligible chunks to unload each tick.
+      The chunks will unload from world chunk map, and save to disk asynchronously.
+
+      See min-chunk-unload-fraction for more.
+      Increasing these takes more tick time on chunk unloading, but may help with
+      memory usage in specific scenarios.
+  min-chunk-unload-fraction:
+    default: "0.05"
+    description: >-
+      The minimum fraction of chunks to unload each tick.
+
+      The final number of chunks unloads per tick is the maximum of
+      min-chunk-unload-count and eligible-chunks * min-chunk-unload-fraction.
   prevent-moving-into-unloaded-chunks:
     default: "false"
     description: >-


### PR DESCRIPTION
https://github.com/PaperMC/Paper/pull/13927

Vanilla unload as much as chunks as possible, if there still gets time before next tick. However Moonrise does not check for tick time

So I'm not sure if I should put vanilla value for `min-chunk-unload-count`