### PR TITLE
Remove mentions of UTF8ResourceBundleControl

### DIFF
--- a/src/content/docs/adventure/localization.md
+++ b/src/content/docs/adventure/localization.md
@@ -117,7 +117,6 @@ GlobalTranslator.translator().addSource(myStore);
 ```
 
 There are additional methods on the message format translation store to bulk register from [resource bundles](jd:java:java.util.ResourceBundle).
-You may also want to use Adventure's `UTF8ResourceBundleControl` utility class to create your bundle.
 
 ### Using MiniMessage for translations
 

--- a/src/content/docs/paper/dev/api/component-api/i18n.md
+++ b/src/content/docs/paper/dev/api/component-api/i18n.md
@@ -38,7 +38,7 @@ some.translation.key=Translated Message: {0}
 ```java
 TranslationStore.StringBased<MessageFormat> store = TranslationStore.messageFormat(Key.key("namespace:value"));
 
-ResourceBundle bundle = ResourceBundle.getBundle("your.plugin.Bundle", Locale.US, UTF8ResourceBundleControl.get());
+ResourceBundle bundle = ResourceBundle.getBundle("your.plugin.Bundle", Locale.US);
 store.registerAll(Locale.US, bundle, true);
 GlobalTranslator.translator().addSource(store);
 ```


### PR DESCRIPTION
This class was removed in Adventure 5.x and is generally not relevant any more due to modern MC using Java >9.