### PR TITLE
chore(paper/config): clarify miscellaneous EAR effects

### DIFF
--- a/src/config/paper/spigot.yml
+++ b/src/config/paper/spigot.yml
@@ -347,6 +347,11 @@ world-settings:
         The chance of lightning occurring during a thunderstorm, as a
         probability of 1/\<thunder-chance> per chunk, every tick.
     entity-activation-range:
+      description: >-
+        The distance in blocks from a player at which entities tick normally.
+        Outside this range, entities tick less frequently. Set to 0 or less to
+        disable activation-range throttling for loaded entities in that category,
+        causing them to tick normally regardless of player distance.
       animals:
         vanilla: "0"
         default: "32"
@@ -363,12 +368,10 @@ world-settings:
         vanilla: "0"
         default: "16"
         description: >-
-          The distance in blocks from a player at which miscellaneous entities,
-          including dropped items, tick normally. Outside this range, entities tick
-          less frequently, which can cause dropped items moving through water streams
-          to appear to lag, rubber-band, or move backward. Set to 0 or less to disable
-          activation-range throttling for miscellaneous entities, causing loaded
-          entities in this category to tick normally regardless of player distance.
+          The entity activation range for miscellaneous entities, including
+          dropped items. Dropped items outside this range may tick less frequently,
+          which can cause items moving through water streams to appear to lag,
+          rubber-band, or move backward.
       water:
         vanilla: "0"
         default: "16"

--- a/src/config/paper/spigot.yml
+++ b/src/config/paper/spigot.yml
@@ -347,11 +347,12 @@ world-settings:
         The chance of lightning occurring during a thunderstorm, as a
         probability of 1/\<thunder-chance> per chunk, every tick.
     entity-activation-range:
-      description: >-
-        The distance in blocks from a player at which entities tick normally.
-        Outside this range, entities tick less frequently. Set to 0 or less to
-        disable activation-range throttling for loaded entities in that category,
-        causing them to tick normally regardless of player distance.
+      header:
+        message: >-
+          The distance in blocks from a player at which entities tick normally.
+          Outside this range, entities tick less frequently. Set to 0 or less to
+          disable activation-range throttling for loaded entities in that category,
+          causing them to tick normally regardless of player distance.
       animals:
         vanilla: "0"
         default: "32"
@@ -369,9 +370,8 @@ world-settings:
         default: "16"
         description: >-
           The entity activation range for miscellaneous entities, including
-          dropped items. Dropped items outside this range may tick less frequently,
-          which can cause items moving through water streams to appear to lag,
-          rubber-band, or move backward.
+          dropped items. Outside of this range, items moving through water
+          streams may appear to visually lag, rubber-band, or move backward.
       water:
         vanilla: "0"
         default: "16"

--- a/src/config/paper/spigot.yml
+++ b/src/config/paper/spigot.yml
@@ -362,7 +362,13 @@ world-settings:
       misc:
         vanilla: "0"
         default: "16"
-        description: The entity activation range for misc entities.
+        description: >-
+          The distance in blocks from a player at which miscellaneous entities,
+          including dropped items, tick normally. Outside this range, entities tick
+          less frequently, which can cause dropped items moving through water streams
+          to appear to lag, rubber-band, or move backward. Set to 0 or less to disable
+          activation-range throttling for miscellaneous entities, causing loaded
+          entities in this category to tick normally regardless of player distance.
       water:
         vanilla: "0"
         default: "16"


### PR DESCRIPTION
## Summary

* Expands the documentation for the miscellaneous entity activation range
* Clarifies that dropped items are affected by this setting
* Explains that reduced ticking outside the range may cause items in water streams to lag or rubber-band
* Documents how setting the value to `0` or less disables activation-range throttling for loaded miscellaneous entities

## Testing

* Ran `pnpm exec prettier "src/config/paper/spigot.yml" --check`
* Ran `pnpm run build`
* Confirmed all internal links are valid

Closes #713
