### PR TITLE
refactor: update userdev docs to improve clarity

### DIFF
--- a/src/content/docs/paper/dev/getting-started/userdev.md
+++ b/src/content/docs/paper/dev/getting-started/userdev.md
@@ -143,7 +143,7 @@ tasks.assemble {
 }
 ```
 
-## 1.20.5 and beyond
+### 1.20.5 and beyond
 
 As of 1.20.5, Paper ships with a Mojang-mapped runtime instead of re-obfuscating the server to Spigot mappings.
 Additionally, CraftBukkit classes will no longer be relocated into a versioned package.
@@ -151,12 +151,12 @@ This requires plugins to be deobfuscated before loading when necessary.
 
 Most of this process is done automatically by paperweight, but there are some important things to know when using server internals (or "NMS") from now on.
 
-### Default mappings assumption
+#### Default mappings assumption
 * By default, all Spigot/Bukkit plugins will be assumed to be Spigot-mapped if they do not specify their mappings namespace in the manifest.
   The other way around, all Paper plugins will be assumed to be Mojang-mapped if they do not specify their mappings namespace in the manifest.
 * Spigot-mapped plugins will need to be deobfuscated on first load, Mojang-mapped plugins will not.
 
-### Compiling to Mojang mappings
+#### Compiling to Mojang mappings
 
 :::note
 
@@ -172,7 +172,7 @@ If you want your main output to use Mojang mappings, you need to remove all `dep
 paperweight.reobfArtifactConfiguration = io.papermc.paperweight.userdev.ReobfArtifactConfiguration.MOJANG_PRODUCTION
 ```
 
-### Compiling to Spigot mappings
+#### Compiling to Spigot mappings
 
 If you want your main output to use Spigot mappings, add the following code to your build script:
 


### PR DESCRIPTION
As written In the discord channel

> I feel like the paperweight section needs a bit of cleanup and rewording. 
> 
> I don’t know if the „1.20.5 and beyond“ still make sense since reobf/spigot mappings isn’t a thing anymore. It kinda confused me until i saw the section above it. IMO we should either move the new part below the old part so the „and beyond“ still makes sense, or we reword that old part entirely. 

This PR just adjust headers so the 1.20.5 section is nested into the reobfuscation section which makes more sense.  I opted out of trying to reword it but i am open to do that as well if the consensus is to do so. 