### PR TITLE
Remove experimental tags in certain docs

### DIFF
--- a/src/content/docs/paper/dev/api/data-component-api.md
+++ b/src/content/docs/paper/dev/api/data-component-api.md
@@ -2,17 +2,7 @@
 title: Data components
 description: A guide to the ItemStack data component API.
 slug: paper/dev/data-component-api
-sidebar:
-  badge:
-    text: Experimental
-    variant: danger
 ---
-
-:::danger[Experimental]
-
-The data component API is currently experimental, and is additionally subject to change across versions.
-
-:::
 
 The data component API provides a version-specific interface for accessing and manipulating item data that is otherwise not representable by the `ItemMeta` API.
 Through this API, you can read and modify properties of an item, so called data components, in a stable and object-oriented manner.

--- a/src/content/docs/paper/dev/api/dialogs.mdx
+++ b/src/content/docs/paper/dev/api/dialogs.mdx
@@ -3,22 +3,12 @@ title: Dialog API
 description: A guide to the dialog API introduced in 1.21.7.
 slug: paper/dev/dialogs
 version: 1.21.8
-sidebar:
-  badge:
-    text: Experimental
-    variant: danger
 ---
 
 import Video from "/src/components/Video.astro";
 
 import DialogShowcaseMp4 from "./assets/dialogs/dialog-showcase.mp4?url";
 import InputDialogShowcaseMp4 from "./assets/dialogs/input-dialog-showcase.mp4?url";
-
-:::danger[Experimental]
-
-The dialog API is currently experimental and might change in the future.
-
-:::
 
 [Dialogs](https://minecraft.wiki/w/Dialog) are a feature added to Minecraft in the [1.21.6](https://minecraft.wiki/w/Java_Edition_1.21.6)
 update. Paper released developer API for creating custom dialogs in 1.21.7. This section is meant

--- a/src/content/docs/paper/dev/api/inventories/menu-type-api.md
+++ b/src/content/docs/paper/dev/api/inventories/menu-type-api.md
@@ -3,17 +3,7 @@ title: Menu Type API
 slug: paper/dev/menu-type-api
 description: A guide to the Menu Type API.
 version: 1.21.8
-sidebar:
-  badge:
-    text: Experimental
-    variant: danger
 ---
-
-:::danger[Experimental]
-
-The Menu Type API and anything that uses it is currently experimental and may change in the future.
-
-:::
 
 Minecraft has a lot of types of menus. From chests, to crafting tables, to anvils, and even villager trade menus.
 With the old Bukkit inventory API, it was not possible to replicate most of these perfectly. Exactly for


### PR DESCRIPTION
Since https://github.com/PaperMC/Paper/commit/7731202e1f96a883d65b1d2eae457cfb06c7d9a8 was merged I thought the docs might need to be updated to reflect that.