### PR TITLE
Document '/velocity:callback' command

### DIFF
--- a/src/content/docs/velocity/admin/reference/commands.md
+++ b/src/content/docs/velocity/admin/reference/commands.md
@@ -85,3 +85,7 @@ players can use this command to view the number of players currently on the prox
 
 If the user has the `velocity.command.send` permission, they can send other players (or all
 players on the proxy) to another server.
+
+## `/velocity:callback`
+
+This command is used internally to execute ClickEvent callbacks.


### PR DESCRIPTION
In Velocity, there is a "/velocity:callback" command that is not documented. Although it is meant for internal use, it should still be in the documentation so that server owners who use Velocity know what it does.