### PR TITLE
feat(minimessage): Add info about requiring namespace for custom textures in paths

### DIFF
--- a/src/content/docs/adventure/minimessage/format.mdx
+++ b/src/content/docs/adventure/minimessage/format.mdx
@@ -549,7 +549,7 @@ Tag
 
 Arguments
   * `atlas` the atlas to use, e.g. `minecraft:blocks`.
-  * `sprite` the sprite to use, e.g. `item/emerald`. Textures added to the atlas from separate namespaces (i.e. textures from `assets/<namespace>/textures/items/`) need to be prefixed with the namespace.
+  * `sprite` the sprite to use, e.g. `item/emerald`. Name is based on the atlas used, may or may not have a prefix (e.g. `item/` for items atlas) and may require a namespace, if the texture is not stored in the `minecraft` namespace (e.g. texture paths from `assets/example/textures/item/` require `example:` as namespace).
 
 Examples
 ```mm

--- a/src/content/docs/adventure/minimessage/format.mdx
+++ b/src/content/docs/adventure/minimessage/format.mdx
@@ -549,12 +549,13 @@ Tag
 
 Arguments
   * `atlas` the atlas to use, e.g. `minecraft:blocks`.
-  * `sprite` the sprite to use, e.g. `item/emerald`.
+  * `sprite` the sprite to use, e.g. `item/emerald`. Textures added to the atlas from separate namespaces (i.e. textures from `assets/<namespace>/textures/items/`) need to be prefixed with the namespace.
 
 Examples
 ```mm
 Look at my <sprite:blocks:block/stone>!
 This item costs 10 x <sprite:"minecraft:items":item/porkchop>.
+This is a custom texture from a namespace: <sprite:items:"example:item/example">
 ```
 
 ### Head


### PR DESCRIPTION
Textures that are added to an atlas from a different namespace require you to add said namespace to the Sprite path to actually show.

Example: Assume a texture called `ruby.png` exists in `assets/example/textures/item/` and is loaded by the items Atlas (due to it collecting everything under `item/` directory).
The correct way to display the sprite now is `<sprite:items:"example:item/ruby">`

This PR updates the docs on the sprite tag to not only mention that, but also that the sprite name to use depends on the atlas, as it may or may not add a prefix for the path to use.