### PR TITLE
fix(docs): fix grammar in command API arguments section

### DIFF
--- a/src/content/docs/paper/dev/api/command-api/basics/arguments-and-literals.md
+++ b/src/content/docs/paper/dev/api/command-api/basics/arguments-and-literals.md
@@ -137,7 +137,7 @@ This is the main advantage of native arguments: The client itself performs simpl
 way better, as they can see invalid input without sending the command to the server.
 
 ### String arguments
-There is three string arguments: `word`, `string`, and `greedyString`.
+There are three string arguments: `word`, `string`, and `greedyString`.
 
 The `word` string argument is the simplest one of these. It only accepts a single word consisting of alphanumerical characters and these special characters: `+`, `-`, `_`, and `.`.
 * ✅ `.this_is_valid_input.`


### PR DESCRIPTION
Correct subject-verb agreement on the Command API basics page ("There is" -> "There are").